### PR TITLE
Add custom logo, primary branding  color and save indicator

### DIFF
--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -13,8 +13,6 @@ import {
 import { useHashrateHistory } from '@/hooks/useHashrateHistory';
 import { formatHashrate, formatUptime, formatDifficulty } from '@/lib/utils';
 import type { Sv1ClientInfo } from '@/types/api';
-import { useUiConfig } from '@/hooks/useUiConfig';
-
 /**
  * Unified Dashboard for the SV2 Mining Stack.
  * 
@@ -32,7 +30,6 @@ export function UnifiedDashboard() {
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 15;
-  const { config } = useUiConfig();
 
   // Data from JDC or Translator depending on mode
   const {
@@ -178,7 +175,7 @@ export function UnifiedDashboard() {
   }, [filteredClients, currentPage, itemsPerPage]);
 
   return (
-    <Shell appMode="translator" appName={config.appName}>
+    <Shell appMode="translator">
       {/* Connection Status Banner */}
       <div className="flex items-center gap-4 text-sm mb-2">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
This PR adds ability for user to add a custom logo which will be displayed in their sidebar and also pick a custom primary color which replaces SV2's default cyan. It also implements reset to  default functioanlity which resets it to default sv2 logo and colors and adds an idicator in the settings that the change is saved since we automatically save them, but user may not be aware of that.

Here's my Coca Cola SV2 UI 😆 

https://github.com/user-attachments/assets/eb1fa21c-4419-40fd-9e0f-6daa5a8c29be

