### PR TITLE
Fix hashrate chart stuck after navigating to settings and back

### DIFF
--- a/src/hooks/useHashrateHistory.ts
+++ b/src/hooks/useHashrateHistory.ts
@@ -18,41 +18,34 @@ const SAMPLE_INTERVAL_MS = 5000; // Sample every 5 seconds
  */
 export function useHashrateHistory(currentHashrate: number | undefined): HashrateDataPoint[] {
   const [history, setHistory] = useState<HashrateDataPoint[]>([]);
-  const lastSampleTime = useRef<number>(0);
+  const hashrateRef = useRef<number | undefined>(currentHashrate);
+
+  // Keep ref in sync with latest value without re-creating the interval
+  useEffect(() => {
+    hashrateRef.current = currentHashrate;
+  }, [currentHashrate]);
 
   useEffect(() => {
-    if (currentHashrate === undefined || currentHashrate === null) return;
+    const interval = setInterval(() => {
+      const value = hashrateRef.current;
+      if (!value) return; // Skip zero and undefined (loading state)
 
-    const now = Date.now();
-    
-    // Only add a new sample if enough time has passed
-    if (now - lastSampleTime.current < SAMPLE_INTERVAL_MS) return;
-    
-    lastSampleTime.current = now;
-    
-    const timeStr = new Date(now).toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
+      const now = Date.now();
+      const timeStr = new Date(now).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
 
-    setHistory(prev => {
-      const newPoint: HashrateDataPoint = {
-        time: timeStr,
-        timestamp: now,
-        hashrate: currentHashrate,
-      };
-      
-      const updated = [...prev, newPoint];
-      
-      // Keep only the last MAX_HISTORY_POINTS
-      if (updated.length > MAX_HISTORY_POINTS) {
-        return updated.slice(-MAX_HISTORY_POINTS);
-      }
-      
-      return updated;
-    });
-  }, [currentHashrate]);
+      setHistory(prev => {
+        const newPoint: HashrateDataPoint = { time: timeStr, timestamp: now, hashrate: value };
+        const updated = [...prev, newPoint];
+        return updated.length > MAX_HISTORY_POINTS ? updated.slice(-MAX_HISTORY_POINTS) : updated;
+      });
+    }, SAMPLE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []); // Run once on mount, clean up on unmount
 
   return history;
 }


### PR DESCRIPTION
The Hashrate History chart would get stuck after visiting the Settings page and returning to the Dashboard.

According to Claude:
> On remount, the hook immediately recorded a 0 sample (from the loading state) and then only re-sampled when the hashrate value actually changed — so on a stable miner it would freeze on that single zero point for several minutes. Replaced the change-triggered effect with a fixed 5-second interval that skips zero values, so the chart collects data reliably and recovers instantly after navigation.

I tested and it works, but needs code review.

## Before 

https://github.com/user-attachments/assets/b1b06ff9-bc5a-470c-8a24-d9b58277d24e

Stuck like this forever...


## After
https://github.com/user-attachments/assets/915c887e-44b9-49fd-a327-b28bf3a8d1b2

