### PR TITLE
Share acceptance in % and minor UI cleanups

### DIFF
--- a/src/components/data/HashrateChart.tsx
+++ b/src/components/data/HashrateChart.tsx
@@ -17,10 +17,67 @@ interface HashrateChartProps {
 }
 
 /**
+ * Computes a clean Y-axis scale targeting ~4 evenly-spaced ticks.
+ * Divides by 3 (not 4) so the step rounds up to a larger nice value,
+ * keeping the final tick count at 4-5 instead of 6-7.
+ */
+function getNiceYAxisScale(values: number[]): {
+  domain: [number, number];
+  ticks: number[];
+} {
+  if (!values.length) return { domain: [0, 10], ticks: [0, 5, 10] };
+
+  const dataMax = Math.max(...values);
+  const dataMin = Math.min(...values);
+
+  if (dataMax === 0) return { domain: [0, 10], ticks: [0, 5, 10] };
+
+  const range = dataMax - dataMin;
+  const topPad  = range === 0 ? dataMax * 0.3 : range * 0.25;
+  const rawMax  = dataMax + topPad;
+  const rawMin  = range === 0 ? 0 : Math.max(0, dataMin - range * 0.1);
+  const rawRange = rawMax - rawMin;
+
+  // Dividing by 3 nudges the step to the next magnitude band,
+  // which naturally produces ~4 ticks instead of 6-7.
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rawRange / 3)));
+  const norm      = (rawRange / 3) / magnitude;
+  const niceNorm  = norm < 1.5 ? 1 : norm < 3 ? 2 : norm < 7 ? 5 : 10;
+  const step      = niceNorm * magnitude;
+
+  const niceMin = Math.floor(rawMin / step) * step;
+  const niceMax = Math.ceil(rawMax  / step) * step;
+
+  const ticks: number[] = [];
+  for (let t = niceMin; t <= niceMax + step * 0.01; t += step) {
+    ticks.push(Math.round(t * 1e10) / 1e10); // strip float noise
+  }
+
+  return { domain: [niceMin, niceMax], ticks };
+}
+
+/**
+ * Y-axis label formatter — strips the ".00" noise that the general
+ * formatHashrate() adds.  Shows integers as-is; keeps one decimal
+ * only when genuinely needed (e.g. "1.5 GH/s").
+ */
+function formatHashrateAxis(value: number): string {
+  if (value === 0) return '0';
+  const units = ['H/s', 'KH/s', 'MH/s', 'GH/s', 'TH/s', 'PH/s', 'EH/s'];
+  const k = 1000;
+  const i = Math.min(Math.floor(Math.log(value) / Math.log(k)), units.length - 1);
+  const v = value / Math.pow(k, i);
+  // Drop the decimal when the tick is a whole number (which it will be
+  // after getNiceYAxisScale snaps to a clean step).
+  const label = Number.isInteger(v) ? String(v) : v.toFixed(1).replace(/\.0$/, '');
+  return `${label} ${units[i]}`;
+}
+
+/**
  * Hashrate history chart component.
  * Displays real accumulated data - no mock data.
  */
-export function HashrateChart({ 
+export function HashrateChart({
   data,
   title = 'Hashrate History',
   description,
@@ -39,20 +96,14 @@ export function HashrateChart({
         </CardHeader>
         <CardContent>
           <div className="h-[200px] w-full flex items-center justify-center text-muted-foreground text-sm">
-            Collecting data... Chart will appear shortly.
+            Collecting data… Chart will appear shortly.
           </div>
         </CardContent>
       </Card>
     );
   }
 
-  // Calculate min/max for better Y axis scaling
-  const hashrates = data.map(d => d.hashrate);
-  const minHashrate = Math.min(...hashrates);
-  const maxHashrate = Math.max(...hashrates);
-  const padding = (maxHashrate - minHashrate) * 0.1 || maxHashrate * 0.1;
-  const yMin = Math.max(0, minHashrate - padding);
-  const yMax = maxHashrate + padding;
+  const { domain, ticks } = getNiceYAxisScale(data.map(d => d.hashrate));
 
   return (
     <Card className="glass-card border-none shadow-sm bg-card/40">
@@ -64,13 +115,14 @@ export function HashrateChart({
           <CardDescription>{description}</CardDescription>
         )}
       </CardHeader>
-      <CardContent className="pl-0">
+      {/* pr-4 keeps the right edge of the chart flush with the card padding */}
+      <CardContent className="pl-2 pr-4">
         <div className="h-[200px] w-full">
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={data}>
+            <AreaChart data={data} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id="colorHashrate" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.3} />
+                  <stop offset="5%"  stopColor="hsl(var(--chart-1))" stopOpacity={0.3} />
                   <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0} />
                 </linearGradient>
               </defs>
@@ -85,16 +137,18 @@ export function HashrateChart({
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
-                dy={10}
+                dy={8}
                 interval="preserveStartEnd"
               />
               <YAxis
                 axisLine={false}
                 tickLine={false}
                 tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
-                domain={[yMin, yMax]}
-                tickFormatter={(value) => formatHashrate(value)}
-                width={70}
+                domain={domain}
+                ticks={ticks}
+                tickFormatter={(v) => formatHashrateAxis(v)}
+                /* wide enough for labels like "1.20 GH/s" without truncation */
+                width={76}
               />
               <Tooltip
                 contentStyle={{

--- a/src/components/data/Sv1ClientTable.tsx
+++ b/src/components/data/Sv1ClientTable.tsx
@@ -30,25 +30,20 @@ export function Sv1ClientTable({ clients, isLoading }: Sv1ClientTableProps) {
     );
   }
 
-  if (clients.length === 0) {
-    return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+  return (
+    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      {clients.length === 0 ? (
         <div className="p-8 text-center text-muted-foreground">
           No SV1 clients connected
         </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      ) : (
       <Table>
         <TableHeader className="bg-muted/30">
           <TableRow className="hover:bg-transparent border-border/40">
             <TableHead className="w-[80px]">ID</TableHead>
             <TableHead>Worker Name</TableHead>
             <TableHead>User Identity</TableHead>
-            <TableHead className="text-right">Hashrate</TableHead>
+            <TableHead>Hashrate</TableHead>
             <TableHead className="hidden md:table-cell">Channel</TableHead>
             <TableHead className="hidden lg:table-cell">Extranonce1</TableHead>
             <TableHead className="hidden xl:table-cell">Version Rolling</TableHead>
@@ -72,7 +67,7 @@ export function Sv1ClientTable({ clients, isLoading }: Sv1ClientTableProps) {
               <TableCell className="text-muted-foreground">
                 {client.user_identity || '-'}
               </TableCell>
-              <TableCell className="text-right font-mono">
+              <TableCell className="font-mono">
                 {client.hashrate !== null ? formatHashrate(client.hashrate) : '-'}
               </TableCell>
               <TableCell className="hidden md:table-cell font-mono text-xs text-muted-foreground">
@@ -96,6 +91,7 @@ export function Sv1ClientTable({ clients, isLoading }: Sv1ClientTableProps) {
           ))}
         </TableBody>
       </Table>
+      )}
     </div>
   );
 }

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -155,20 +155,20 @@ export function Shell({ children, appMode = 'translator', connectionStatus, pool
           </nav>
 
           {/* Right side */}
-          <div className="ml-auto flex items-center gap-2">
+          <div className="ml-auto flex items-center gap-2 min-w-0">
             {connectionStatus && (
               <>
                 {/* Mobile: dot + uptime only (no status text to save space) */}
-                <span className="flex sm:hidden items-center gap-2 text-xs text-muted-foreground">
+                <span className="flex sm:hidden items-center gap-2 text-xs text-muted-foreground min-w-0">
                   <span className={cn('h-2 w-2 rounded-full shrink-0', {
                     'bg-green-500': connectionStatus === 'connected',
                     'bg-red-500': connectionStatus === 'disconnected',
                     'bg-yellow-500 animate-pulse': connectionStatus === 'connecting',
                   })} />
-                  Uptime: {formatUptime(uptime ?? 0)}
+                  <span className="truncate">Uptime: {formatUptime(uptime ?? 0)}</span>
                 </span>
                 {/* Desktop: dot + full status text + uptime */}
-                <span className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground shrink-0">
                   <span className={cn('h-2 w-2 rounded-full shrink-0', {
                     'bg-green-500': connectionStatus === 'connected',
                     'bg-red-500': connectionStatus === 'disconnected',
@@ -180,14 +180,14 @@ export function Shell({ children, appMode = 'translator', connectionStatus, pool
                     ? 'Connecting...'
                     : 'Disconnected'}
                 </span>
-                <span className="hidden sm:block text-xs text-muted-foreground border-l border-border pl-2">
+                <span className="hidden sm:block text-xs text-muted-foreground border-l border-border pl-2 shrink-0">
                   Uptime: {formatUptime(uptime ?? 0)}
                 </span>
               </>
             )}
 
             {/* Theme toggle — desktop only (mobile: in hamburger) */}
-            <span className="hidden sm:block"><ThemeBtn /></span>
+            <span className="hidden sm:block shrink-0"><ThemeBtn /></span>
 
             {/* Hamburger — mobile only */}
             <button

--- a/src/components/setup/MinerConnectionInfo.tsx
+++ b/src/components/setup/MinerConnectionInfo.tsx
@@ -40,8 +40,16 @@ export function MinerConnectionInfo({ isJdMode, centered = false }: MinerConnect
     </p>
   );
 
+  // When only one card is shown (SV1-only mode) it should stretch to full width.
+  // In JD mode two cards sit side-by-side on md+ screens.
+  const wrapperClass = centered
+    ? 'flex flex-wrap justify-center gap-3'
+    : isJdMode
+      ? 'grid gap-3 md:grid-cols-2'
+      : 'grid gap-3';
+
   return (
-    <div className={centered ? 'flex flex-wrap justify-center gap-3' : 'grid gap-3 md:grid-cols-2'}>
+    <div className={wrapperClass}>
       <div className={`p-4 rounded-xl border border-border bg-card space-y-2${centered ? ' w-full max-w-sm' : ''}`}>
         <div className="font-semibold text-sm">SV1 Firmware</div>
         <div className="text-xs text-muted-foreground">Point to the Translator Proxy</div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -53,7 +53,7 @@ export function Settings() {
       poolName={poolName ?? undefined}
       uptime={uptime}
     >
-      <div className="max-w-5xl mx-auto space-y-8">
+      <div className="space-y-8">
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-2xl font-bold tracking-tight">Settings</h2>

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -232,17 +232,48 @@ export function UnifiedDashboard() {
         />
 
         <StatCard
-          title="Shares to Pool"
-          value={
-            <span>
-              {shareStats.submitted.toLocaleString()}
-              {shareStats.rejected > 0 
-                ? <span className="text-red-500 text-lg font-normal"> ({shareStats.rejected} rejected)</span>
-                : <span className="text-green-500 text-lg font-normal"> (0 rejected)</span>
-              }
-            </span>
-          }
-          subtitle={`via ${poolChannelCount} channel(s)`}
+          title="Share Acceptance"
+          value={(() => {
+            const { submitted, rejected } = shareStats;
+            if (submitted === 0) return <span className="text-muted-foreground">—</span>;
+
+            const rate = ((submitted - rejected) / submitted) * 100;
+
+            // ── Label ──────────────────────────────────────────────────────
+            // Zero rejections → exact "100%".
+            // Any rejections  → 2 decimal places so even 0.01% rejection is
+            //   visible. Cap at "99.99%" so floating-point can never round up
+            //   to "100.00%" and falsely imply a clean run.
+            const label = rejected === 0
+              ? '100%'
+              : `${Math.min(rate, 99.99).toFixed(2)}%`;
+
+            // ── Colour ─────────────────────────────────────────────────────
+            // Green ONLY when literally zero rejections — "99.80%" must never
+            //   look the same as a perfect run.
+            // Neutral (default foreground) for high rates with minor rejects.
+            // Yellow 95–99 %, red below 95 %.
+            const colorClass = rejected === 0
+              ? 'text-green-500'
+              : rate >= 99
+                ? ''                  // neutral — noticeable but not alarming
+                : rate >= 95
+                  ? 'text-yellow-500'
+                  : 'text-red-500';
+
+            return <span className={colorClass}>{label}</span>;
+          })()}
+          subtitle={(() => {
+            const { submitted, rejected } = shareStats;
+            if (submitted === 0) return `via ${poolChannelCount} channel(s)`;
+            const rejectionRate = (rejected / submitted) * 100;
+            // Show exact "0%" when clean; cap display at 0.01% so it never
+            // rounds down to "0.00%" when there ARE rejections.
+            const rejRateLabel = rejected === 0
+              ? '0%'
+              : `${Math.max(rejectionRate, 0.01).toFixed(2)}%`;
+            return `${submitted.toLocaleString()} submitted · ${rejected.toLocaleString()} rejected (${rejRateLabel})`;
+          })()}
         />
 
         <StatCard
@@ -272,26 +303,21 @@ export function UnifiedDashboard() {
         </div>
       )}
 
-      {/* Actions Bar - Sticky Header */}
+      {/* Actions Bar */}
       {!poolLoading && (
-        <div className="sticky top-0 z-30 bg-background/60 backdrop-blur-xl py-3 -mx-6 px-6 md:-mx-8 md:px-8 border-y border-border/40 transition-all duration-200 shadow-sm supports-[backdrop-filter]:bg-background/60 mt-8 mb-0">
-          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 max-w-7xl mx-auto">
-            <div className="flex items-center gap-2 w-full sm:w-auto">
-              <div className="relative w-full sm:w-72">
-                <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  placeholder="Search workers..."
-                  className="w-full pl-9 h-9 bg-muted/30 border border-border/50 focus:bg-background transition-all rounded-lg text-sm outline-none focus:ring-2 focus:ring-primary/20"
-                  value={searchTerm}
-                  onChange={(e) => {
-                    setSearchTerm(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                />
-              </div>
-            </div>
-
+        <div className="flex items-center gap-2">
+          <div className="relative w-full sm:w-72">
+            <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search workers..."
+              className="w-full pl-9 h-9 bg-muted/30 border border-border/50 focus:bg-background transition-all rounded-lg text-sm outline-none focus:ring-2 focus:ring-primary/20"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setCurrentPage(1);
+              }}
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
Minor stylistical changes, most important one being that share acceptance is now in %.

## Before
<img width="1301" height="1072" alt="Screenshot 2026-03-24 at 12 23 03" src="https://github.com/user-attachments/assets/b51a864c-d6b2-41f4-8023-64c315fe6cae" />
<img width="1312" height="1082" alt="Screenshot 2026-03-24 at 12 23 07" src="https://github.com/user-attachments/assets/bd6d4010-21d1-4fec-9618-ba08d613e562" />


## After
<img width="1326" height="1101" alt="Screenshot 2026-03-24 at 12 20 00" src="https://github.com/user-attachments/assets/11237118-317c-449e-9ec6-328c1b7ff956" />
<img width="1285" height="1070" alt="Screenshot 2026-03-24 at 12 20 06" src="https://github.com/user-attachments/assets/5fb7556a-6aab-4e23-a8ef-3dcd306e9a19" />
