### PR TITLE
update Docker images version `v0.3.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ docker run --rm \
   -e HOST_HOME=$HOME \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v sv2-config:/app/data/config \
-  stratumv2/sv2-ui:main
+  stratumv2/sv2-ui:v0.3.1
 ```
 
 Then open **http://localhost:8080**. On first run, you'll be guided through the setup wizard.
@@ -31,7 +31,7 @@ docker run --rm --name sv2-ui -p 8080:8080 \
   -e HOST_HOME=$HOME \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v sv2-config:/app/data/config \
-  stratumv2/sv2-ui:main
+  stratumv2/sv2-ui:v0.3.1
 ```
 
 ### macOS (Colima / OrbStack)
@@ -44,14 +44,14 @@ docker run --rm --name sv2-ui -p 8080:8080 \
   -e HOST_HOME=$HOME \
   -v $HOME/.colima/default/docker.sock:/var/run/docker.sock \
   -v sv2-config:/app/data/config \
-  stratumv2/sv2-ui:main
+  stratumv2/sv2-ui:v0.3.1
 
 # OrbStack
 docker run --rm --name sv2-ui -p 8080:8080 \
   -e HOST_HOME=$HOME \
   -v $HOME/.orbstack/run/docker.sock:/var/run/docker.sock \
   -v sv2-config:/app/data/config \
-  stratumv2/sv2-ui:main
+  stratumv2/sv2-ui:v0.3.1
 ```
 
 ## Development
@@ -153,8 +153,8 @@ sv2-ui/
 
 ## Docker Images Used
 
-- `stratumv2/translator_sv2:main` - Translator Proxy
-- `stratumv2/jd_client_sv2:main` - JD Client
+- `stratumv2/translator_sv2:v0.3.1` - Translator Proxy
+- `stratumv2/jd_client_sv2:v0.3.1` - JD Client
 
 ## Ports
 

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -144,8 +144,8 @@ const NETWORK_NAME = 'sv2-network';
 const CONFIG_VOLUME = 'sv2-config';
 const TRANSLATOR_CONTAINER = 'sv2-translator';
 const JDC_CONTAINER = 'sv2-jdc';
-const TRANSLATOR_IMAGE = 'stratumv2/translator_sv2:main';
-const JDC_IMAGE = 'stratumv2/jd_client_sv2:main';
+const TRANSLATOR_IMAGE = 'stratumv2/translator_sv2:v0.3.1';
+const JDC_IMAGE = 'stratumv2/jd_client_sv2:v0.3.1';
 
 /**
  * Detect if we're running inside a Docker container.


### PR DESCRIPTION
This PR updates the docker images' versions of JDC and tProxy, matching the ones which are gonna be published after the patch release (`v0.3.1`) on `sv2-apps`.