### PR TITLE
Enable BlitzPool

### DIFF
--- a/src/components/setup/steps/PoolConfigStep.tsx
+++ b/src/components/setup/steps/PoolConfigStep.tsx
@@ -56,9 +56,8 @@ const SOLO_POOLS: KnownPool[] = [
     name: 'Blitzpool',
     address: 'blitzpool.yourdevice.ch',
     port: 3333,
-    authority_public_key: '',
+    authority_public_key: '9bCoFxTszKCuffyywH5uS5o6WcU4vsjTH2axxc7wE86y2HhvULU',
     description: 'Solo mining pool by Blitzpool',
-    badge: 'coming-soon',
     logoUrl: '/blitzpool.svg',
   },
   {


### PR DESCRIPTION
BlitzPool by @warioishere [added SV2 compatibility](https://blitzpool.yourdevice.ch/#/stratum-v2), this PR simply removes `coming soon` label and adds authority key.

I've tested it with a CPU miner and after a while was able to see shares.


<img width="1309" height="986" alt="Screenshot 2026-04-01 at 15 28 56" src="https://github.com/user-attachments/assets/5f737400-b659-4331-9ba3-dafe0ae8b6aa" />
<img width="1846" height="751" alt="Screenshot 2026-04-01 at 15 33 50" src="https://github.com/user-attachments/assets/0064d1e6-52fc-4715-863e-49ea2c5f2013" />
