### PR TITLE
feat: add version rolling informational tooltip to dashboard tables

### DIFF
--- a/src/components/data/Sv1ClientTable.tsx
+++ b/src/components/data/Sv1ClientTable.tsx
@@ -85,7 +85,16 @@ export function Sv1ClientTable({ clients, isLoading, sortKey, sortDir, onSort }:
               </TableHead>
               <TableHead className="hidden md:table-cell">Channel</TableHead>
               <TableHead className="hidden lg:table-cell">Extranonce1</TableHead>
-              <TableHead className="hidden xl:table-cell">Version Rolling</TableHead>
+              <TableHead className="hidden xl:table-cell">
+                <span className="flex items-center gap-1">
+                  Version Rolling
+                  <InfoPopover>
+                    Version rolling lets the miner change certain allowed bits in the block version while
+                    looking for valid shares. This gives the miner a bit more room to search. The mask
+                    shows which bits can be changed.
+                  </InfoPopover>
+                </span>
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/src/components/data/UpstreamChannelTable.tsx
+++ b/src/components/data/UpstreamChannelTable.tsx
@@ -6,6 +6,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { InfoPopover } from '@/components/ui/info-popover';
 import { formatHashrate, formatDifficulty, truncateHex, formatNumber } from '@/lib/utils';
 import type { ServerExtendedChannelInfo, ServerStandardChannelInfo } from '@/types/api';
 
@@ -61,7 +62,16 @@ export function UpstreamChannelTable({
             <TableHead className="text-right">Shares</TableHead>
             <TableHead className="text-right hidden md:table-cell">Best Diff</TableHead>
             <TableHead className="hidden lg:table-cell">Target</TableHead>
-            <TableHead className="hidden xl:table-cell">Version Rolling</TableHead>
+            <TableHead className="hidden xl:table-cell">
+              <span className="flex items-center gap-1">
+                Version Rolling
+                <InfoPopover>
+                  Version rolling lets the miner change certain allowed bits in the block version while
+                  looking for valid shares. This gives the miner a bit more room to search. The mask
+                  shows which bits can be changed.
+                </InfoPopover>
+              </span>
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>


### PR DESCRIPTION
This PR adds a human-readable informational tooltip to the "Version Rolling" column in the mining dashboard tables (Issue #53).

1. Feature: Integrated the ```<InfoPopover>``` component into the headers of ```Sv1ClientTable``` and ```UpstreamChannelTable```.
2. Content: Provides a clear explanation of how version rolling expands a miner's search space by modifying bits in the block version.
3. Aesthetics: Follows existing design systems and ensures the icon is only visible on wide viewports (>1280px).

**Verification**
1. Confirmed tooltip renders and displays correctly on hover/click.
2. The code passes ```npm run lint``` and ```npm run typecheck``` with 0 warnings.
Closes #53

<img width="1920" height="912" alt="version_rolling_tooltip_final_1775242482086" src="https://github.com/user-attachments/assets/deadc92d-f99a-4f7a-a9d7-4f310223a801" />
