### PR TITLE
feat: add time range selector to hashrate chart (5m/15m/1h)

### DIFF
--- a/src/components/data/HashrateChart.tsx
+++ b/src/components/data/HashrateChart.tsx
@@ -11,11 +11,15 @@ import {
 } from 'recharts';
 import { formatHashrate } from '@/lib/utils';
 
+export type TimeRange = '5m' | '15m' | '1h';
+
 interface HashrateChartProps {
   data: { time: string; hashrate: number }[];
   title?: string;
   description?: string;
   info?: ReactNode;
+  timeRange?: TimeRange;
+  onTimeRangeChange?: (range: TimeRange) => void;
 }
 
 /**
@@ -79,21 +83,51 @@ function formatHashrateAxis(value: number): string {
  * Hashrate history chart component.
  * Displays real accumulated data - no mock data.
  */
+const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: '5m', label: '5 min' },
+  { value: '15m', label: '15 min' },
+  { value: '1h', label: '1 hr' },
+];
+
 export function HashrateChart({
   data,
   title = 'Hashrate History',
   description,
   info,
+  timeRange,
+  onTimeRangeChange,
 }: HashrateChartProps) {
+  const rangeSelector = timeRange && onTimeRangeChange ? (
+    <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-xs">
+      {TIME_RANGE_OPTIONS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => onTimeRangeChange(value)}
+          className={`px-2.5 py-1 rounded-sm font-medium transition-all ${
+            timeRange === value
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  ) : null;
+
   // Don't render chart if no data
   if (!data || data.length === 0) {
     return (
       <Card className="glass-card border-none shadow-sm bg-card/40">
         <CardHeader>
-          <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
-            {title}
-            {info}
-          </CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
+              {title}
+              {info}
+            </CardTitle>
+            {rangeSelector}
+          </div>
           {description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
         <CardContent>
@@ -110,10 +144,13 @@ export function HashrateChart({
   return (
     <Card className="glass-card border-none shadow-sm bg-card/40">
       <CardHeader>
-        <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
-          {title}
-          {info}
-        </CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
+            {title}
+            {info}
+          </CardTitle>
+          {rangeSelector}
+        </div>
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
       {/* pr-4 keeps the right edge of the chart flush with the card padding */}

--- a/src/hooks/useHashrateHistory.ts
+++ b/src/hooks/useHashrateHistory.ts
@@ -6,7 +6,7 @@ export interface HashrateDataPoint {
   hashrate: number;
 }
 
-const MAX_HISTORY_POINTS = 60; // Keep last 60 data points
+const MAX_HISTORY_POINTS = 720; // Keep up to 1 hour of data (at 5-second intervals)
 const SAMPLE_INTERVAL_MS = 5000; // Sample every 5 seconds
 
 function storageKeyFor(configKey: string): string {

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -4,7 +4,7 @@ import { InfoPopover } from '@/components/ui/info-popover';
 import { MinerConnectionInfo } from '@/components/setup/MinerConnectionInfo';
 import { Shell } from '@/components/layout/Shell';
 import { StatCard } from '@/components/data/StatCard';
-import { HashrateChart } from '@/components/data/HashrateChart';
+import { HashrateChart, type TimeRange } from '@/components/data/HashrateChart';
 import {
   DownstreamWorkerTable,
   type ChannelType,
@@ -23,6 +23,13 @@ import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useConnectionStatus } from '@/hooks/useConnectionStatus';
 import { formatHashrate, formatDifficulty } from '@/lib/utils';
 import type { Sv1ClientInfo } from '@/types/api';
+
+const RANGE_MS: Record<TimeRange, number> = { '5m': 5 * 60_000, '15m': 15 * 60_000, '1h': 60 * 60_000 };
+const RANGE_DESCRIPTIONS: Record<TimeRange, string> = {
+  '5m': 'Last 5 minutes · sampled every 5 seconds',
+  '15m': 'Last 15 minutes · sampled every 5 seconds',
+  '1h': 'Last hour · sampled every 5 seconds',
+};
 
 function normalizeUserIdentity(userIdentity: string) {
   return userIdentity.trim().toLowerCase();
@@ -51,6 +58,7 @@ export function UnifiedDashboard() {
   const [currentPage, setCurrentPage] = useState(1);
   const [sortKey, setSortKey] = useState<DownstreamWorkerSortKey>('connection_id');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [timeRange, setTimeRange] = useState<TimeRange>('5m');
   const itemsPerPage = 15;
 
   // Get configured template mode from setup status
@@ -224,6 +232,12 @@ export function UnifiedDashboard() {
   // a false zero into persisted history on page refresh (see issue #57).
   const hashrateForHistory = poolGlobal ? totalHashrate : undefined;
   const hashrateHistory = useHashrateHistory(hashrateForHistory, historyConfigKey);
+
+  // Filter history to the selected time range for chart display
+  const filteredHistory = useMemo(() => {
+    const cutoff = Date.now() - RANGE_MS[timeRange];
+    return hashrateHistory.filter(p => p.timestamp > cutoff);
+  }, [hashrateHistory, timeRange]);
 
   // Shares data from upstream SERVER channels (shares sent TO the Pool)
   const shareStats = useMemo(() => {
@@ -476,9 +490,11 @@ export function UnifiedDashboard() {
 
       {/* Main Chart - Real data accumulated over time */}
       <HashrateChart
-        data={hashrateHistory}
+        data={filteredHistory}
         title="Hashrate History"
-        description="Real-time data sampled every 5 seconds"
+        description={RANGE_DESCRIPTIONS[timeRange]}
+        timeRange={timeRange}
+        onTimeRangeChange={setTimeRange}
         info={
           <InfoPopover>
             Estimated hashrate sampled every 5 seconds. May take a few minutes to reflect your miner's actual output.


### PR DESCRIPTION
## Title
add time range selector to hashrate chart

## Body

### Summary

- added 5 min / 15 min / 1 hr toggle buttons to the hashrate chart
- hook now stores up to 1 hour of data instead of just 5 minutes
- chart filters based on selected range and description updates accordingly

### Test plan

- stop the translator so it doesnt overwrite with zeros: docker stop sv2-translator
- refresh the page first to clear any old intervals
- open the console and paste this to inject 1hr of fake data:

```js
localStorage.removeItem('sv2_hashrate_history:no-jd:Braiins Pool');
const now = Date.now();
const points = Array.from({length: 720}, (_, i) => ({
  time: new Date(now-(720-i)*5000).toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',hour12:false}),
  timestamp: now-(720-i)*5000,
  hashrate: 800+Math.random()*200 + Math.sin(i/30)*100
}));
localStorage.setItem('sv2_hashrate_history:no-jd:Braiins Pool', JSON.stringify(points));
```
- refresh again to load the data
- click through 5m, 15m, 1hr and check chart scales properly

https://github.com/user-attachments/assets/4dd434ce-497f-4fbd-ab7e-8b612c4f6e0b


**closes** #56