### PR TITLE
add `Blocks Found` top card

### DIFF
--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'wouter';
+import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -14,16 +15,56 @@ import {
   Trash2,
 } from 'lucide-react';
 
+function clearPersistedDashboardState() {
+  if (typeof window === 'undefined') return;
+
+  const prefixes = [
+    'sv2_hashrate_history:',
+    'sv2_blocks_found:',
+    'sv2_best_diff:',
+  ];
+
+  const keysToRemove: string[] = [];
+
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    if (key && prefixes.some((prefix) => key.startsWith(prefix))) {
+      keysToRemove.push(key);
+    }
+  }
+
+  keysToRemove.forEach((key) => {
+    window.localStorage.removeItem(key);
+  });
+}
+
 /**
  * Configuration tab for Settings page.
  * Shows current setup and allows reconfiguration.
  */
 export function ConfigurationTab() {
   const [, navigate] = useLocation();
+  const queryClient = useQueryClient();
   const [config, setConfig] = useState<SetupData | null>(null);
   const [loading, setLoading] = useState(true);
   const { isOrchestrated, isConfigured, isRunning, miningMode, mode } = useSetupStatus();
   const { stop, restart, isStoppingOrRestarting, stopError, restartError } = useControlApi();
+
+  const clearDashboardClientState = () => {
+    clearPersistedDashboardState();
+
+    [
+      ['pool-global'],
+      ['server-channels'],
+      ['sv2-clients'],
+      ['sv1-clients'],
+      ['translator-server-channels'],
+      ['translator-health'],
+      ['jdc-health'],
+    ].forEach((queryKey) => {
+      queryClient.removeQueries({ queryKey });
+    });
+  };
 
   useEffect(() => {
     if (isOrchestrated && isConfigured) {
@@ -37,6 +78,7 @@ export function ConfigurationTab() {
   }, [isOrchestrated, isConfigured]);
 
   const handleReconfigure = () => {
+    clearDashboardClientState();
     navigate('/setup');
   };
 
@@ -57,6 +99,7 @@ export function ConfigurationTab() {
       try {
         const response = await fetch('/api/reset', { method: 'POST' });
         if (response.ok) {
+          clearDashboardClientState();
           window.location.href = '/setup';
         }
       } catch (error) {

--- a/src/hooks/usePersistentBlocksFound.ts
+++ b/src/hooks/usePersistentBlocksFound.ts
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export interface PersistedMetricEntry {
+  key: string;
+  value: number;
+}
+
+type PersistedMetricState = Record<string, number>;
+
+function storageKeyFor(metricKey: string, configKey: string): string {
+  return `sv2_${metricKey}:${configKey}`;
+}
+
+function loadFromStorage(metricKey: string, configKey: string): PersistedMetricState {
+  try {
+    const stored = localStorage.getItem(storageKeyFor(metricKey, configKey));
+    if (stored) {
+      return JSON.parse(stored) as PersistedMetricState;
+    }
+  } catch {
+    // Ignore parse errors and start fresh.
+  }
+
+  return {};
+}
+
+function usePersistentMetric(
+  entries: PersistedMetricEntry[],
+  configKey: string,
+  metricKey: string,
+): PersistedMetricState {
+  const [persistedCounts, setPersistedCounts] = useState<PersistedMetricState>(
+    () => loadFromStorage(metricKey, configKey),
+  );
+
+  const storageKeyRef = useRef<string>(storageKeyFor(metricKey, configKey));
+
+  useEffect(() => {
+    storageKeyRef.current = storageKeyFor(metricKey, configKey);
+    setPersistedCounts(loadFromStorage(metricKey, configKey));
+  }, [configKey, metricKey]);
+
+  useEffect(() => {
+    if (entries.length === 0) return;
+
+    setPersistedCounts((prev) => {
+      let changed = false;
+      const next = { ...prev };
+
+      entries.forEach(({ key, value }) => {
+        const normalizedValue = Math.max(0, value);
+        if ((next[key] ?? 0) < normalizedValue) {
+          next[key] = normalizedValue;
+          changed = true;
+        }
+      });
+
+      if (!changed) {
+        return prev;
+      }
+
+      try {
+        localStorage.setItem(storageKeyRef.current, JSON.stringify(next));
+      } catch {
+        // Ignore storage errors (private browsing quota, etc.)
+      }
+
+      return next;
+    });
+  }, [entries]);
+
+  return persistedCounts;
+}
+
+export function usePersistentBlocksFound(
+  entries: PersistedMetricEntry[],
+  configKey: string,
+): number {
+  const persistedCounts = usePersistentMetric(entries, configKey, 'blocks_found');
+
+  return useMemo(
+    () => Object.values(persistedCounts).reduce((sum, count) => sum + count, 0),
+    [persistedCounts],
+  );
+}
+
+export function usePersistentBestDifficulty(
+  entries: PersistedMetricEntry[],
+  configKey: string,
+): number {
+  const persistedCounts = usePersistentMetric(entries, configKey, 'best_diff');
+
+  return useMemo(
+    () => Math.max(0, ...Object.values(persistedCounts)),
+    [persistedCounts],
+  );
+}

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -19,6 +19,10 @@ import {
   useTranslatorServerChannels,
 } from '@/hooks/usePoolData';
 import { useHashrateHistory } from '@/hooks/useHashrateHistory';
+import {
+  usePersistentBestDifficulty,
+  usePersistentBlocksFound,
+} from '@/hooks/usePersistentBlocksFound';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useConnectionStatus } from '@/hooks/useConnectionStatus';
 import { formatHashrate, formatDifficulty } from '@/lib/utils';
@@ -81,7 +85,6 @@ export function UnifiedDashboard() {
     global: poolGlobal,
     sv2Clients,
     isSv2ClientsLoading,
-    clientChannels,  // Downstream client channels (for hashrate, best diff)
     serverChannels,  // Upstream server channels (for shares to Pool)
     isLoading: poolLoading,
     isError: poolError,
@@ -267,6 +270,66 @@ export function UnifiedDashboard() {
     return hashrateHistory.filter(p => p.timestamp > cutoff);
   }, [hashrateHistory, timeRange]);
 
+  const blocksFoundEntries = useMemo(() => {
+    if (isJdMode) {
+      if (!sv2Clients) return [];
+
+      return sv2Clients.flatMap((client) => [
+        ...client.extended_channels.map((channel) => ({
+          key: `jdc:${client.client_id}:extended:${channel.channel_id}:${channel.user_identity}`,
+          value: channel.blocks_found,
+        })),
+        ...client.standard_channels.map((channel) => ({
+          key: `jdc:${client.client_id}:standard:${channel.channel_id}:${channel.user_identity}`,
+          value: channel.blocks_found,
+        })),
+      ]);
+    }
+
+    if (!serverChannels) return [];
+
+    return [
+      ...serverChannels.extended_channels.map((channel) => ({
+        key: `translator:server:extended:${channel.channel_id}:${channel.user_identity}`,
+        value: channel.blocks_found,
+      })),
+      ...serverChannels.standard_channels.map((channel) => ({
+        key: `translator:server:standard:${channel.channel_id}:${channel.user_identity}`,
+        value: channel.blocks_found,
+      })),
+    ];
+  }, [isJdMode, serverChannels, sv2Clients]);
+
+  const bestDiffEntries = useMemo(() => {
+    if (isJdMode) {
+      if (!sv2Clients) return [];
+
+      return sv2Clients.flatMap((client) => [
+        ...client.extended_channels.map((channel) => ({
+          key: `jdc:${client.client_id}:extended:${channel.channel_id}:${channel.user_identity}`,
+          value: channel.best_diff,
+        })),
+        ...client.standard_channels.map((channel) => ({
+          key: `jdc:${client.client_id}:standard:${channel.channel_id}:${channel.user_identity}`,
+          value: channel.best_diff,
+        })),
+      ]);
+    }
+
+    if (!serverChannels) return [];
+
+    return [
+      ...serverChannels.extended_channels.map((channel) => ({
+        key: `translator:server:extended:${channel.channel_id}:${channel.user_identity}`,
+        value: channel.best_diff,
+      })),
+      ...serverChannels.standard_channels.map((channel) => ({
+        key: `translator:server:standard:${channel.channel_id}:${channel.user_identity}`,
+        value: channel.best_diff,
+      })),
+    ];
+  }, [isJdMode, serverChannels, sv2Clients]);
+
   // Shares data from upstream SERVER channels (shares sent TO the Pool)
   const shareStats = useMemo(() => {
     if (!serverChannels) {
@@ -288,27 +351,8 @@ export function UnifiedDashboard() {
       rejected: extRejected + stdRejected,
     };
   }, [serverChannels]);
-
-  // Best difficulty:
-  // - JD mode: from SV2 client channels
-  // - Translator-only mode: not available from SV1 clients API (no best_diff field)
-  const bestDiff = useMemo(() => {
-    if (!isJdMode) {
-      // Translator doesn't expose best_diff for SV1 clients
-      // We could potentially get it from server channels instead
-      if (!serverChannels) return 0;
-      const extBest = Math.max(...serverChannels.extended_channels.map(ch => ch.best_diff), 0);
-      const stdBest = Math.max(...serverChannels.standard_channels.map(ch => ch.best_diff), 0);
-      return Math.max(extBest, stdBest);
-    }
-    
-    if (!clientChannels) return 0;
-    
-    const extBest = Math.max(...clientChannels.extended_channels.map(ch => ch.best_diff), 0);
-    const stdBest = Math.max(...clientChannels.standard_channels.map(ch => ch.best_diff), 0);
-    
-    return Math.max(extBest, stdBest);
-  }, [isJdMode, clientChannels, serverChannels]);
+  const blocksFound = usePersistentBlocksFound(blocksFoundEntries, historyConfigKey);
+  const bestDiff = usePersistentBestDifficulty(bestDiffEntries, historyConfigKey);
 
   // Number of upstream pool channels (for shares subtitle)
   const poolChannelCount = (serverChannels?.total_extended || 0) + (serverChannels?.total_standard || 0);
@@ -317,6 +361,9 @@ export function UnifiedDashboard() {
   const clientChannelCount = isJdMode 
     ? downstreamWorkerCount
     : sv1ActiveCount;
+  const bestDiffSubtitle = clientChannelCount > 0
+    ? `from ${clientChannelCount} client channel(s)`
+    : undefined;
 
   type DashboardWorkerRow = DownstreamWorkerRow & { search_text: string };
 
@@ -429,7 +476,7 @@ export function UnifiedDashboard() {
       )}
 
       {/* Hero Stats Section */}
-      <div className={isSovereignSolo ? 'grid gap-4 md:grid-cols-2 lg:grid-cols-3' : 'grid gap-4 md:grid-cols-2 lg:grid-cols-4'}>
+      <div className={isSovereignSolo ? 'grid gap-4 md:grid-cols-2 lg:grid-cols-4' : 'grid gap-4 md:grid-cols-2 lg:grid-cols-5'}>
         <StatCard
           title="Total Estimated Hashrate"
           value={formatHashrate(totalHashrate)}
@@ -457,6 +504,11 @@ export function UnifiedDashboard() {
               ? `${userFacingDownstreamConnectionCount} downstream connection(s)`
               : `${totalWorkers - activeWorkers} offline workers`
           }
+        />
+
+        <StatCard
+          title="Blocks Found"
+          value={blocksFound.toLocaleString()}
         />
 
         {!isSovereignSolo && (
@@ -496,7 +548,7 @@ export function UnifiedDashboard() {
         <StatCard
           title="Best Difficulty"
           value={bestDiff > 0 ? formatDifficulty(bestDiff) : '-'}
-          subtitle={`from ${clientChannelCount} client channel(s)`}
+          subtitle={bestDiffSubtitle}
         />
       </div>
 


### PR DESCRIPTION
close #68 

the card is being added to all UI flows, but it's only testable on signet via "JD" and "sovereign solo" flows (because that's where we can tweak the `node.sock` path to a `signet` datadir)

this is how it looks for JD and solo flows:
<img width="1058" height="877" alt="image" src="https://github.com/user-attachments/assets/14de85ec-78ae-417d-95f5-875ae085428d" />



sovereign solo:
<img width="1056" height="868" alt="image" src="https://github.com/user-attachments/assets/eb17f4f4-d76d-4e5a-8722-af3da49a2e32" />
