### PR TITLE
add socket path validation during setup

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -13,7 +13,7 @@ import type { ContainerLogLine, LogContainerRole, LogOutputStream } from './logs
  * Uses HOST_HOME env var (passed from docker run) if available,
  * otherwise falls back to os.homedir() (works in development).
  */
-function expandHomePath(inputPath: string): string {
+export function expandHomePath(inputPath: string): string {
   if (inputPath.startsWith('~')) {
     const home = process.env.HOST_HOME || os.homedir();
     return inputPath.replace('~', home);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@
 
 import express from 'express';
 import cors from 'cors';
+import net from 'net';
 import path from 'path';
 import fs from 'fs/promises';
 import { fileURLToPath } from 'url';
@@ -19,6 +20,7 @@ import {
   isDockerAvailable,
   ensureDockerAvailable,
   getDockerConnectionInfo,
+  expandHomePath,
 } from './docker.js';
 import { getLogDiagnostics } from './logs/diagnostics.js';
 
@@ -123,6 +125,63 @@ app.get('/api/config', async (_req, res) => {
     console.error('Config error:', error);
     res.status(500).json({ error: 'Failed to get config' });
   }
+});
+
+/**
+ * Try to open the Unix socket to confirm something is actually listening.
+ * Filesystem checks are not enough — Bitcoin Core leaves its socket file on
+ * disk after a crash, so stat() would return a stale "valid" result.
+ */
+function probeUnixSocket(socketPath: string, timeoutMs = 1000): Promise<{ valid: true } | { valid: false; error: string }> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ path: socketPath });
+    let settled = false;
+    const finish = (result: { valid: true } | { valid: false; error: string }) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish({ valid: true }));
+    socket.once('timeout', () => finish({
+      valid: false,
+      error: `Socket did not respond within ${timeoutMs}ms. Bitcoin Core may be unresponsive.`,
+    }));
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      switch (err.code) {
+        case 'ENOENT':
+          finish({ valid: false, error: `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.` });
+          break;
+        case 'ECONNREFUSED':
+          finish({ valid: false, error: `Socket file exists at ${socketPath} but nothing is listening. Bitcoin Core may have crashed or been stopped.` });
+          break;
+        case 'EACCES':
+          finish({ valid: false, error: `Permission denied for ${socketPath}. Check that the sv2-ui process can read this file.` });
+          break;
+        case 'ENOTSOCK':
+          finish({ valid: false, error: `Path ${socketPath} is not a Unix socket.` });
+          break;
+        default:
+          finish({ valid: false, error: err.message || 'Unknown error connecting to socket' });
+      }
+    });
+  });
+}
+
+/**
+ * POST /api/validate/bitcoin-socket - Check if a Bitcoin Core IPC socket is listening
+ */
+app.post('/api/validate/bitcoin-socket', async (req, res) => {
+  const { socket_path } = req.body;
+  if (!socket_path || typeof socket_path !== 'string') {
+    return res.status(400).json({ valid: false, error: 'socket_path is required' });
+  }
+
+  const resolved = expandHomePath(socket_path);
+  const result = await probeUnixSocket(resolved);
+  return res.json(result);
 });
 
 /**

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -156,21 +156,21 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
         <p id="socket-path-hint" className="text-xs text-muted-foreground mt-2">Click to edit if your socket is in a different location.</p>
 
         {isChecking && (
-          <div className="flex items-center gap-2 mt-3 text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
+          <div className="flex items-center gap-2 mt-3 px-3 py-2 rounded-md bg-muted/50 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
             <span className="text-xs">Checking socket path...</span>
           </div>
         )}
         {!isChecking && isValid && (
-          <div className="flex items-center gap-2 mt-3 text-sv2-green">
-            <CheckCircle2 className="h-4 w-4" />
-            <span className="text-xs">Socket is listening</span>
+          <div className="flex items-center gap-2 mt-3 px-3 py-2 rounded-md bg-success/20 text-success">
+            <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+            <span className="text-xs font-medium">Socket is listening</span>
           </div>
         )}
         {!isChecking && socketError && (
-          <div className="flex items-start gap-2 mt-3 text-sv2-red">
+          <div className="flex items-start gap-2 mt-3 px-3 py-2 rounded-md bg-destructive/20 text-destructive">
             <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
-            <span className="text-xs">{socketError}</span>
+            <span className="text-xs font-medium">{socketError}</span>
           </div>
         )}
       </div>

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -7,6 +7,9 @@ function getDefaultDataDir(os: OperatingSystem): string {
   return os === 'linux' ? '~/.bitcoin' : '~/Library/Application Support/Bitcoin';
 }
 
+// Bitcoin Core places its IPC socket under the data directory: mainnet at the
+// datadir root, other networks under a <network>/ subdirectory. Validation is
+// network-agnostic — only the default path differs.
 function computeSocketPath(os: OperatingSystem, network: 'mainnet' | 'testnet4', customDataDir: string): string {
   const dataDir = customDataDir.trim() || getDefaultDataDir(os);
   return network === 'mainnet' ? `${dataDir}/node.sock` : `${dataDir}/testnet4/node.sock`;
@@ -156,21 +159,33 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
         <p id="socket-path-hint" className="text-xs text-muted-foreground mt-2">Click to edit if your socket is in a different location.</p>
 
         {isChecking && (
-          <div className="flex items-center gap-2 mt-3 px-3 py-2 rounded-md bg-muted/50 text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
-            <span className="text-xs">Checking socket path...</span>
+          <div
+            className="mt-3 p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground flex gap-3 items-center"
+            role="status"
+            aria-live="polite"
+          >
+            <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" aria-hidden="true" />
+            <span>Checking socket path...</span>
           </div>
         )}
         {!isChecking && isValid && (
-          <div className="flex items-center gap-2 mt-3 px-3 py-2 rounded-md bg-success/20 text-success">
-            <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
-            <span className="text-xs font-medium">Socket is listening</span>
+          <div
+            className="mt-3 p-3 rounded-lg bg-success/10 border border-success/20 text-sm text-success flex gap-3 items-center"
+            role="status"
+            aria-live="polite"
+          >
+            <CheckCircle2 className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <span>Socket is listening</span>
           </div>
         )}
         {!isChecking && socketError && (
-          <div className="flex items-start gap-2 mt-3 px-3 py-2 rounded-md bg-destructive/20 text-destructive">
-            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
-            <span className="text-xs font-medium">{socketError}</span>
+          <div
+            className="mt-3 p-3 rounded-lg bg-destructive/[0.08] text-sm text-destructive flex gap-3 items-start"
+            role="alert"
+            aria-live="assertive"
+          >
+            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <span>{socketError}</span>
           </div>
         )}
       </div>

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { StepProps, BitcoinConfig, OperatingSystem } from '../types';
-import { Bitcoin, Apple, Terminal, Pencil, Check } from 'lucide-react';
+import { Bitcoin, Apple, Terminal, Pencil, Check, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { useBitcoinSocketValidation } from '@/hooks/useBitcoinSocketValidation';
 
 function getDefaultDataDir(os: OperatingSystem): string {
   return os === 'linux' ? '~/.bitcoin' : '~/Library/Application Support/Bitcoin';
@@ -23,6 +24,8 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
   useEffect(() => {
     updateData({ bitcoin: { os, network, customDataDir, socket_path: socketPath } as BitcoinConfig });
   }, [os, network, customDataDir, socketPath, updateData]);
+
+  const { isChecking, isValid, error: socketError } = useBitcoinSocketValidation(socketPath);
 
   const resetPath = () => { setManualSocketPath(''); setIsEditingPath(false); };
 
@@ -151,13 +154,33 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
           </button>
         )}
         <p id="socket-path-hint" className="text-xs text-muted-foreground mt-2">Click to edit if your socket is in a different location.</p>
+
+        {isChecking && (
+          <div className="flex items-center gap-2 mt-3 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-xs">Checking socket path...</span>
+          </div>
+        )}
+        {!isChecking && isValid && (
+          <div className="flex items-center gap-2 mt-3 text-sv2-green">
+            <CheckCircle2 className="h-4 w-4" />
+            <span className="text-xs">Socket is listening</span>
+          </div>
+        )}
+        {!isChecking && socketError && (
+          <div className="flex items-start gap-2 mt-3 text-sv2-red">
+            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+            <span className="text-xs">{socketError}</span>
+          </div>
+        )}
       </div>
 
       <div className="flex justify-center">
         <button
           type="button"
           onClick={onNext}
-          className="h-11 px-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors font-medium"
+          disabled={!isChecking && !!socketError}
+          className="h-11 px-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Continue
         </button>

--- a/src/hooks/useBitcoinSocketValidation.ts
+++ b/src/hooks/useBitcoinSocketValidation.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface SocketValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// Returns null when the backend is not reachable (standalone mode — skip validation).
+async function validateSocket(socketPath: string): Promise<SocketValidationResult | null> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 2000);
+
+    const response = await fetch('/api/validate/bitcoin-socket', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ socket_path: socketPath }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) return null;
+    return response.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a Bitcoin Core IPC socket path against the backend. Debounces the
+ * input so we don't probe on every keystroke, and silently no-ops when the
+ * backend isn't reachable (standalone mode).
+ */
+export function useBitcoinSocketValidation(socketPath: string, debounceMs = 800) {
+  const [debouncedPath, setDebouncedPath] = useState(socketPath);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedPath(socketPath), debounceMs);
+    return () => clearTimeout(t);
+  }, [socketPath, debounceMs]);
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['bitcoin-socket-validation', debouncedPath],
+    queryFn: () => validateSocket(debouncedPath),
+    enabled: !!debouncedPath,
+    staleTime: 10_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const isPathStale = debouncedPath !== socketPath;
+
+  return {
+    isChecking: isFetching || isPathStale,
+    isValid: data?.valid === true,
+    error: data && !data.valid ? data.error : undefined,
+    skipped: data === null,
+  };
+}


### PR DESCRIPTION
## Title
add socket path validation and fix jdc bind mount for testnet4

## Body

### what this does

when you set up JD mode and the bitcoin core socket path is wrong or doesn't exist, the wizard used to just let you through and then JDC would crash-loop with a confusing "cannot connect to pool" error on the dashboard. you had no idea the actual problem was the socket path.

this adds a validation check on the bitcoin core setup step — it hits the backend to verify the socket exists before you can continue. if its missing you get a clear message like "socket not found at /path — make sure bitcoin core is running with IPC enabled" and the continue button is blocked.

### changes

- server/src/docker.ts — exported expandHomePath
- server/src/index.ts — added POST /api/validate/bitcoin-socket endpoint
- src/components/setup/steps/BitcoinSetup.tsx — added debounced socket validation with inline status display

### test plan

- go through setup with JD mode on testnet4 with bitcoin core running — should show green "socket found" and complete setup
- try with a wrong path — should show red error and block continue
- check that JDC container actually connects to the socket after setup (no more crash-loop)

partially address #83

https://github.com/user-attachments/assets/9466869e-c3cc-425a-b706-509083b6ae98

