### PR TITLE
show diagnostic for `unknown-user` when connecting to Braiins pool

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -277,23 +277,23 @@ async function connectSv2UiToNetwork(): Promise<void> {
   try {
     // Find sv2-ui container (could be named sv2-ui or sv2-ui-test)
     const containers = await docker.listContainers({ all: true });
-    const sv2UiContainer = containers.find(c => 
+    const sv2UiContainer = containers.find(c =>
       c.Names.some(n => n === '/sv2-ui' || n === '/sv2-ui-test')
     );
-    
+
     if (!sv2UiContainer) {
       // Not running in Docker (development mode)
       return;
     }
-    
+
     const network = docker.getNetwork(NETWORK_NAME);
     const networkInfo = await network.inspect();
-    
+
     // Check if already connected
     if (networkInfo.Containers && networkInfo.Containers[sv2UiContainer.Id]) {
       return;
     }
-    
+
     console.log('Connecting sv2-ui to sv2-network...');
     await network.connect({ Container: sv2UiContainer.Id });
   } catch {
@@ -345,7 +345,7 @@ async function getContainerStatus(name: string): Promise<ContainerStatus | null>
   try {
     const container = docker.getContainer(name);
     const info = await container.inspect();
-    
+
     let status: HealthStatus = 'stopped';
     if (info.State.Running) {
       status = info.State.Health?.Status === 'healthy' ? 'healthy' : 'starting';
@@ -421,13 +421,13 @@ async function startJdc(
 
   const binds = isRunningInDocker
     ? [
-        `${CONFIG_VOLUME}:/config:ro`,
-        `${bitcoinSocketPath}:/root/.bitcoin/node.sock:ro`,
-      ]
+      `${CONFIG_VOLUME}:/config:ro`,
+      `${bitcoinSocketPath}:/root/.bitcoin/node.sock:ro`,
+    ]
     : [
-        `${configPath}:/config/jdc.toml:ro`,
-        `${bitcoinSocketPath}:/root/.bitcoin/node.sock:ro`,
-      ];
+      `${configPath}:/config/jdc.toml:ro`,
+      `${bitcoinSocketPath}:/root/.bitcoin/node.sock:ro`,
+    ];
 
   const container = await docker.createContainer({
     Image: JDC_IMAGE,

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -233,13 +233,21 @@ export async function readContainerLogs(
   try {
     const dockerContainer = docker.getContainer(LOG_CONTAINER_NAMES[container]);
     const info = await dockerContainer.inspect();
-    const logBuffer = await dockerContainer.logs({
+    const startTime = info.State?.StartedAt;
+
+    const logOptions: Docker.LogsOptions = {
       stdout: true,
       stderr: true,
       timestamps: true,
-      tail: options.tail,
+      tail: options.tail ?? 200,
       abortSignal: AbortSignal.timeout(2000),
-    });
+    };
+
+    if (startTime) {
+      logOptions.since = Math.floor(new Date(startTime).getTime() / 1000);
+    }
+
+    const logBuffer = await dockerContainer.logs(logOptions);
 
     const chunks = info.Config?.Tty
       ? [{ stream: 'stdout' as const, payload: logBuffer.toString('utf-8') }]

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -404,7 +404,7 @@ async function startTranslator(configPath: string): Promise<void> {
         '9092/tcp': [{ HostPort: '9092' }],
       },
       NetworkMode: NETWORK_NAME,
-      RestartPolicy: { Name: 'always' },
+      RestartPolicy: { Name: 'no' },
     },
     ExposedPorts: {
       '34255/tcp': {},

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -126,6 +126,95 @@ app.get('/api/config', async (_req, res) => {
 });
 
 /**
+ * PUT /api/config - Update configuration and restart with new values
+ */
+app.put('/api/config', async (req, res) => {
+  try {
+    const state = await loadState();
+
+    if (!state.configured || !state.data) {
+      return res.status(400).json({ success: false, error: 'No configuration to update' });
+    }
+
+    const updates = req.body as Partial<SetupData>;
+    const currentData = state.data;
+    const newData: SetupData = {
+      ...currentData,
+      ...updates,
+      mode: updates.mode ?? currentData.mode,
+      miningMode: updates.miningMode ?? currentData.miningMode,
+      pool: updates.pool ?? currentData.pool,
+      bitcoin: updates.bitcoin ?? currentData.bitcoin,
+      jdc: updates.jdc ?? currentData.jdc,
+      translator: updates.translator ?? currentData.translator,
+    };
+
+    const requiresPool = !(newData.miningMode === 'solo' && newData.mode === 'jd');
+
+    if (!newData.mode || !newData.translator || (requiresPool && !newData.pool)) {
+      return res.status(400).json({ success: false, error: 'Missing required configuration' });
+    }
+
+    if (newData.mode === 'jd' && (!newData.jdc || !newData.bitcoin)) {
+      return res.status(400).json({ success: false, error: 'JD mode requires JDC and Bitcoin configuration' });
+    }
+
+    await ensureDockerAvailable();
+
+    await fs.mkdir(CONFIG_DIR, { recursive: true });
+
+    const translatorPath = path.join(CONFIG_DIR, 'translator.toml');
+    const jdcPath = path.join(CONFIG_DIR, 'jdc.toml');
+
+    try {
+      const translatorStat = await fs.stat(translatorPath);
+      if (translatorStat.isDirectory()) {
+        await fs.rm(translatorPath, { recursive: true });
+      }
+    } catch {
+      // translatorPath doesn't exist or isn't a directory, ignore
+    }
+
+    try {
+      const jdcStat = await fs.stat(jdcPath);
+      if (jdcStat.isDirectory()) {
+        await fs.rm(jdcPath, { recursive: true });
+      }
+    } catch {
+      // jdcPath doesn't exist or isn't a directory, ignore
+    }
+
+    const translatorConfig = generateTranslatorConfig(newData);
+    await fs.writeFile(translatorPath, translatorConfig);
+    console.log('Updated translator.toml');
+
+    if (newData.mode === 'jd') {
+      const jdcConfig = generateJdcConfig(newData);
+      if (jdcConfig) {
+        await fs.writeFile(jdcPath, jdcConfig);
+        console.log('Updated jdc.toml');
+      }
+    }
+
+    await saveState(newData);
+
+    await stopStack();
+
+    await startStack(newData, CONFIG_DIR);
+
+    const response: SetupResponse = { success: true };
+    res.json(response);
+  } catch (error) {
+    console.error('Config update error:', error);
+    const response: SetupResponse = {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update config',
+    };
+    res.status(500).json(response);
+  }
+});
+
+/**
  * GET /api/logs/diagnostics - Get collated log diagnostics for the deployed stack
  */
 app.get('/api/logs/diagnostics', async (_req, res) => {

--- a/server/src/logs/parsers.ts
+++ b/server/src/logs/parsers.ts
@@ -1,8 +1,52 @@
-import type { ContainerLogLine, LogDiagnostic, LogParser } from './types.js';
+import type {
+  ContainerLogLine,
+  DiagnosticEvidence,
+  DiagnosticSeverity,
+  LogDiagnostic,
+  LogParser,
+} from './types.js';
+
+const UNKNOWN_USER_REGEX =
+  /OpenMiningChannelError\(request_id: \d+, error_code: unknown-user\)/;
+
+function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
+  const matches = lines.filter(
+    ({ container, message }) =>
+      container === 'translator' && UNKNOWN_USER_REGEX.test(message)
+  );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const evidence: DiagnosticEvidence[] = matches.map(
+    ({ container, stream, timestamp, raw }) => ({
+      container,
+      stream,
+      timestamp,
+      line: raw,
+    })
+  );
+
+  return {
+    code: 'unknown-user',
+    severity: 'warning' as DiagnosticSeverity,
+    title: 'Invalid Braiins username',
+    message: 'The Braiins username is not recognized by the pool.',
+    recommendation:
+      'Verify the Braiins username in your settings matches the pool account exactly.',
+    streamId: 'mining-services',
+    containers: ['translator'],
+    detectedAt: matches[0].timestamp,
+    evidence,
+  };
+}
 
 // Central registry for scenario-specific parsers. New log-derived diagnostics
 // should be added here without changing the collection pipeline.
-export const logParsers: LogParser[] = [];
+export const logParsers: LogParser[] = [
+  { code: 'unknown-user', match: unknownUserParser },
+];
 
 function toDiagnosticsArray(
   diagnostic: LogDiagnostic | LogDiagnostic[] | null

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { InlineEditField } from '@/components/ui/inline-edit-field';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
 import type { SetupData } from '@/components/setup/types';
@@ -48,7 +49,7 @@ export function ConfigurationTab() {
   const [config, setConfig] = useState<SetupData | null>(null);
   const [loading, setLoading] = useState(true);
   const { isOrchestrated, isConfigured, isRunning, miningMode, mode } = useSetupStatus();
-  const { stop, restart, isStoppingOrRestarting, stopError, restartError } = useControlApi();
+  const { stop, restart, isStoppingOrRestarting, stopError, restartError, updateConfig, isUpdatingConfig, updateConfigError } = useControlApi();
 
   const clearDashboardClientState = () => {
     clearPersistedDashboardState();
@@ -227,13 +228,13 @@ export function ConfigurationTab() {
       </Card>
 
       {/* Error Messages */}
-      {(stopError || restartError) && (
+      {(stopError || restartError || updateConfigError) && (
         <Card className="border-red-500/30 bg-red-500/5">
           <CardContent className="pt-6">
             <div className="flex gap-3">
               <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0" />
               <p className="text-sm text-red-500">
-                {stopError?.message || restartError?.message || 'Operation failed'}
+                {stopError?.message || restartError?.message || updateConfigError?.message || 'Operation failed'}
               </p>
             </div>
           </CardContent>
@@ -348,10 +349,27 @@ export function ConfigurationTab() {
 
             return (
               <div className="p-4 rounded-lg border border-border/50 bg-muted/20">
-                <p className="font-medium mb-1">
-                  {isSovereignSolo ? 'Miner Identity' : isSoloMode ? 'Bitcoin Address' : 'Pool Username'}
-                </p>
-                <p className="font-mono text-sm truncate">{identity}</p>
+                <InlineEditField
+                  label={isSovereignSolo ? 'Miner Identity' : isSoloMode ? 'Bitcoin Address' : 'Pool Username'}
+                  value={identity}
+                  onSave={(newValue) => {
+                    if (!config?.translator) return;
+                    updateConfig({
+                      translator: {
+                        enable_vardiff: config.translator.enable_vardiff,
+                        aggregate_channels: config.translator.aggregate_channels,
+                        min_hashrate: config.translator.min_hashrate,
+                        user_identity: newValue,
+                      },
+                    }, {
+                      onSuccess: () => {
+                        getCurrentConfig().then(setConfig);
+                      },
+                    });
+                  }}
+                  isLoading={isUpdatingConfig}
+                  error={updateConfigError}
+                />
               </div>
             );
           })()}

--- a/src/components/ui/inline-edit-field.tsx
+++ b/src/components/ui/inline-edit-field.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { Input } from './input';
+import { Button } from './button';
+import { Pencil, Check, X, Loader2 } from 'lucide-react';
+
+interface InlineEditFieldProps {
+  label: string;
+  value: string;
+  onSave: (newValue: string) => void;
+  isLoading?: boolean;
+  error?: Error | null;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+}
+
+export function InlineEditField({
+  label,
+  value,
+  onSave,
+  isLoading = false,
+  error = null,
+  inputProps,
+}: InlineEditFieldProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+
+  const startEditing = () => {
+    setEditValue(value);
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setEditValue(value);
+    setIsEditing(false);
+  };
+
+  const save = () => {
+    if (!editValue.trim()) {
+      cancelEditing();
+      return;
+    }
+    onSave(editValue.trim());
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <p className="font-medium">{label}</p>
+        {!isEditing && !isLoading && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2"
+            onClick={startEditing}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+      {isEditing ? (
+        <div className="flex items-center gap-2">
+          <Input
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') save();
+              if (e.key === 'Escape') cancelEditing();
+            }}
+            className="font-mono text-sm h-8"
+            autoFocus
+            disabled={isLoading}
+            {...inputProps}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={save}
+            disabled={isLoading}
+          >
+            {isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={cancelEditing}
+            disabled={isLoading}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      ) : (
+        <p className="font-mono text-sm truncate">{value}</p>
+      )}
+      {error && (
+        <p className="text-xs text-red-500">{error.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useControlApi.ts
+++ b/src/hooks/useControlApi.ts
@@ -59,8 +59,8 @@ export function useControlApi() {
   const stopMutation = useMutation({
     mutationFn: stopServices,
     onSuccess: () => {
-      // Invalidate status queries
       queryClient.invalidateQueries({ queryKey: ['setup-status'] });
+      queryClient.invalidateQueries({ queryKey: ['log-diagnostics'] });
     },
   });
 
@@ -68,6 +68,7 @@ export function useControlApi() {
     mutationFn: restartServices,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['setup-status'] });
+      queryClient.invalidateQueries({ queryKey: ['log-diagnostics'] });
     },
   });
 
@@ -75,6 +76,7 @@ export function useControlApi() {
     mutationFn: setupServices,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['setup-status'] });
+      queryClient.invalidateQueries({ queryKey: ['log-diagnostics'] });
     },
   });
 
@@ -82,6 +84,7 @@ export function useControlApi() {
     mutationFn: updateConfigService,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['setup-status'] });
+      queryClient.invalidateQueries({ queryKey: ['log-diagnostics'] });
     },
   });
 

--- a/src/hooks/useControlApi.ts
+++ b/src/hooks/useControlApi.ts
@@ -39,6 +39,18 @@ async function setupServices(config: SetupData): Promise<ControlResponse> {
 }
 
 /**
+ * Update configuration and restart (inline edit)
+ */
+async function updateConfigService(updates: Partial<SetupData>): Promise<ControlResponse> {
+  const response = await fetch('/api/config', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  });
+  return response.json();
+}
+
+/**
  * Hook for controlling services (stop/restart)
  */
 export function useControlApi() {
@@ -66,15 +78,25 @@ export function useControlApi() {
     },
   });
 
+  const updateConfigMutation = useMutation({
+    mutationFn: updateConfigService,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['setup-status'] });
+    },
+  });
+
   return {
     stop: stopMutation.mutate,
     restart: restartMutation.mutate,
     setup: setupMutation.mutate,
+    updateConfig: updateConfigMutation.mutate,
     isStoppingOrRestarting: stopMutation.isPending || restartMutation.isPending,
     isSettingUp: setupMutation.isPending,
+    isUpdatingConfig: updateConfigMutation.isPending,
     stopError: stopMutation.error,
     restartError: restartMutation.error,
     setupError: setupMutation.error,
+    updateConfigError: updateConfigMutation.error,
   };
 }
 

--- a/src/hooks/useLogDiagnostics.ts
+++ b/src/hooks/useLogDiagnostics.ts
@@ -21,7 +21,7 @@ export function useLogDiagnostics(enabled = true) {
   return useQuery({
     queryKey: ['log-diagnostics'],
     queryFn: fetchLogDiagnostics,
-    refetchInterval: enabled ? 10000 : false,
+    refetchInterval: enabled ? 3000 : false,
     retry: false,
     enabled,
   });

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -26,6 +26,7 @@ import {
 import { isAggregatedTproxyPoolName } from '@/components/setup/poolRules';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useConnectionStatus } from '@/hooks/useConnectionStatus';
+import { useLogDiagnostics } from '@/hooks/useLogDiagnostics';
 import { formatHashrate, formatDifficulty } from '@/lib/utils';
 import type { Sv1ClientInfo } from '@/types/api';
 
@@ -109,6 +110,10 @@ export function UnifiedDashboard() {
   const jdcDown           = isJdMode && !jdcHealthLoading && !jdcHealthy;
   const showError         = poolError || translatorDown || jdcDown;
   const configuredButStopped = isOrchestrated && isConfigured && !isRunning;
+
+  // log-derived diagnostics from the API
+  const { data: logDiagnostics } = useLogDiagnostics();
+  const diagnostics = logDiagnostics?.diagnostics ?? [];
   const [isStarting, setIsStarting] = useState(false);
 
   const handleStartMining = async () => {
@@ -485,6 +490,27 @@ export function UnifiedDashboard() {
           </span>
         </div>
       )}
+
+      {/* log-derived Diagnostic Banners */}
+      {diagnostics.map((diagnostic) => (
+        <div
+          key={diagnostic.code}
+          className={`flex items-start gap-3 rounded-xl border px-5 py-4 text-sm ${
+            diagnostic.severity === 'error'
+              ? 'border-red-500/40 bg-red-500/10 text-red-500'
+              : 'border-amber-500/40 bg-amber-500/10 text-amber-500'
+          }`}
+        >
+          <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+          <div className="flex flex-col gap-1">
+            <span className="font-medium">{diagnostic.title}</span>
+            <span>{diagnostic.message}</span>
+            {diagnostic.recommendation && (
+              <span className="text-current/80">{diagnostic.recommendation}</span>
+            )}
+          </div>
+        </div>
+      ))}
 
       {/* Hero Stats Section */}
       <div className={isSovereignSolo ? 'grid gap-4 md:grid-cols-2 lg:grid-cols-4' : 'grid gap-4 md:grid-cols-2 lg:grid-cols-5'}>


### PR DESCRIPTION
closes #86 
lay the foundations for #21 

a few changes were needed beyond implementing the parser:

1. updated the `RestartPolicy` of the tproxy container. With automatic restarts, the diagnostic banner would repeatedly blink as the container restarted. The container now stops on failure, since it cannot fully initialize in this state.

2. Adjusted log parsing to consider only entries from the current container start time onward. This avoids false diagnostics caused by logs from previous runs. For example, if a prior run failed due to an unknown user but was later fixed, the old error logs could still trigger the diagnostic within the 200-line threshold.


<img width="2492" height="1364" alt="image" src="https://github.com/user-attachments/assets/898641b2-bf0e-488c-b365-ca296fe68cc8" />

--

togive the user the ability fix the `unknown-user` error, which requires correcting `user_identity`, I also started groundwork for #21:

1. added a `PUT` endpoint to accept partial config updates and apply them where needed.
2. built a reusable inline editing component.
3. updated the dashboard to support inline editing of the pool username, avoiding full reconfiguration.

<img width="2540" height="1700" alt="image" src="https://github.com/user-attachments/assets/cf9ae8af-4b01-4c20-8dbf-0538a5911e01" />

