### PR TITLE
fix: polish light mode component visibility

### DIFF
--- a/src/components/data/DownstreamWorkerTable.tsx
+++ b/src/components/data/DownstreamWorkerTable.tsx
@@ -88,7 +88,7 @@ export function DownstreamWorkerTable({
 }: DownstreamWorkerTableProps) {
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden shadow-sm">
         <div className="p-8 text-center text-muted-foreground">
           Loading workers...
         </div>
@@ -97,7 +97,7 @@ export function DownstreamWorkerTable({
   }
 
   return (
-    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+    <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden shadow-sm">
       {workers.length === 0 ? (
         <div className="p-8 text-center text-muted-foreground">
           No workers connected
@@ -105,7 +105,7 @@ export function DownstreamWorkerTable({
       ) : (
         <Table>
           <TableHeader className="bg-muted/30">
-            <TableRow className="hover:bg-transparent border-border/40">
+            <TableRow className="hover:bg-transparent border-border/60">
               <TableHead className="w-[132px] cursor-pointer select-none whitespace-nowrap" onClick={() => onSort('connection_id')}>
                 <span className="flex items-center gap-1 whitespace-nowrap hover:text-foreground transition-colors">
                   Connection Id
@@ -159,7 +159,7 @@ export function DownstreamWorkerTable({
           </TableHeader>
           <TableBody>
             {workers.map((worker) => (
-              <TableRow key={`${worker.connection_id}-${worker.channel_type}-${worker.channel_id ?? 'na'}-${worker.user_identity}`} className="hover:bg-muted/20 border-border/40 group">
+              <TableRow key={`${worker.connection_id}-${worker.channel_type}-${worker.channel_id ?? 'na'}-${worker.user_identity}`} className="hover:bg-muted/20 border-border/60 group">
                 <TableCell className="font-mono text-xs text-muted-foreground">
                   {worker.connection_id}
                 </TableCell>

--- a/src/components/data/HashrateChart.tsx
+++ b/src/components/data/HashrateChart.tsx
@@ -119,7 +119,7 @@ export function HashrateChart({
   // Don't render chart if no data
   if (!data || data.length === 0) {
     return (
-      <Card className="glass-card border-none shadow-sm bg-card/40">
+      <Card className="glass-card shadow-sm bg-card/60">
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
@@ -142,7 +142,7 @@ export function HashrateChart({
   const { domain, ticks } = getNiceYAxisScale(data.map(d => d.hashrate));
 
   return (
-    <Card className="glass-card border-none shadow-sm bg-card/40">
+    <Card className="glass-card shadow-sm bg-card/60">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">

--- a/src/components/data/StatCard.tsx
+++ b/src/components/data/StatCard.tsx
@@ -30,7 +30,7 @@ export function StatCard({
   className,
 }: StatCardProps) {
   return (
-    <Card className={cn('glass-card border-none shadow-md bg-card/40', className)}>
+    <Card className={cn('glass-card shadow-md bg-card/60', className)}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
           {title}

--- a/src/components/data/UpstreamChannelTable.tsx
+++ b/src/components/data/UpstreamChannelTable.tsx
@@ -26,7 +26,7 @@ export function UpstreamChannelTable({
 }: UpstreamChannelTableProps) {
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden shadow-sm">
         <div className="p-8 text-center text-muted-foreground">
           Loading channels...
         </div>
@@ -41,7 +41,7 @@ export function UpstreamChannelTable({
 
   if (allChannels.length === 0) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden shadow-sm">
         <div className="p-8 text-center text-muted-foreground">
           No upstream channels
         </div>
@@ -50,10 +50,10 @@ export function UpstreamChannelTable({
   }
 
   return (
-    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+    <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm overflow-hidden shadow-sm">
       <Table>
         <TableHeader className="bg-muted/30">
-          <TableRow className="hover:bg-transparent border-border/40">
+          <TableRow className="hover:bg-transparent border-border/60">
             <TableHead className="w-[80px]">Channel</TableHead>
             <TableHead>Type</TableHead>
             <TableHead>User Identity</TableHead>
@@ -66,7 +66,7 @@ export function UpstreamChannelTable({
         </TableHeader>
         <TableBody>
           {allChannels.map((channel) => (
-            <TableRow key={`${channel.type}-${channel.channel_id}`} className="hover:bg-muted/20 border-border/40">
+            <TableRow key={`${channel.type}-${channel.channel_id}`} className="hover:bg-muted/20 border-border/60">
               <TableCell className="font-mono text-xs">
                 {channel.channel_id}
               </TableCell>

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -227,7 +227,7 @@ export function Shell({
             menuOpen ? 'max-h-48 opacity-100' : 'max-h-0 opacity-0'
           )}
         >
-          <nav className="px-4 pb-3 pt-1 flex flex-col gap-0.5 border-t border-border/40">
+          <nav className="px-4 pb-3 pt-1 flex flex-col gap-0.5 border-t border-border/60">
             {navItems.map((item) => {
               const isActive =
                 location === item.href ||

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -261,7 +261,7 @@ export function ConfigurationTab() {
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Mining Mode */}
-          <div className="flex items-center justify-between p-4 rounded-lg border border-border/50 bg-muted/20">
+          <div className="flex items-center justify-between p-4 rounded-lg border border-border/60 bg-muted/40">
             <div>
               <p className="font-medium">Mining Mode</p>
               <p className="text-sm text-muted-foreground">
@@ -274,14 +274,14 @@ export function ConfigurationTab() {
             </Badge>
           </div>
 
-          <div className="p-4 rounded-lg border border-border/50 bg-muted/20">
+          <div className="p-4 rounded-lg border border-border/60 bg-muted/40">
             <p className="font-medium mb-1">Block Templates</p>
             <p className="text-sm text-muted-foreground">{templateModeLabel}</p>
           </div>
 
           {/* Pool */}
           {!isSovereignSolo && config.pool && (
-            <div className="p-4 rounded-lg border border-border/50 bg-muted/20">
+            <div className="p-4 rounded-lg border border-border/60 bg-muted/40">
               <p className="font-medium">{config.pool.name}</p>
               <p className="text-muted-foreground font-mono text-xs">
                 {config.pool.address}:{config.pool.port}
@@ -321,7 +321,7 @@ export function ConfigurationTab() {
               }
 
               return (
-                <div className="p-4 rounded-lg border border-border/50 bg-muted/20 space-y-2">
+                <div className="p-4 rounded-lg border border-border/60 bg-muted/40 space-y-2">
                   {addr && (
                     <div>
                       <p className="font-medium mb-1">Payout Address</p>
@@ -347,7 +347,7 @@ export function ConfigurationTab() {
             }
 
             return (
-              <div className="p-4 rounded-lg border border-border/50 bg-muted/20">
+              <div className="p-4 rounded-lg border border-border/60 bg-muted/40">
                 <p className="font-medium mb-1">
                   {isSovereignSolo ? 'Miner Identity' : isSoloMode ? 'Bitcoin Address' : 'Pool Username'}
                 </p>
@@ -358,7 +358,7 @@ export function ConfigurationTab() {
 
           {/* Bitcoin Core (JD mode) */}
           {isJdMode && config.bitcoin && (
-            <div className="p-4 rounded-lg border border-border/50 bg-muted/20 space-y-2">
+            <div className="p-4 rounded-lg border border-border/60 bg-muted/40 space-y-2">
               <div className="flex items-center gap-2">
                 <p className="font-medium">Bitcoin Core</p>
                 <Badge variant="outline" className="text-xs">{config.bitcoin.network}</Badge>
@@ -371,7 +371,7 @@ export function ConfigurationTab() {
 
           {/* Fallback Address (JD mode) */}
           {isJdMode && config.jdc?.coinbase_reward_address && (
-            <div className="p-4 rounded-lg border border-border/50 bg-muted/20">
+            <div className="p-4 rounded-lg border border-border/60 bg-muted/40">
               <p className="font-medium mb-1">{isSovereignSolo ? 'Block Reward Address' : 'Fallback Address'}</p>
               <p className="text-muted-foreground font-mono text-xs truncate">
                 {config.jdc.coinbase_reward_address}

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -202,7 +202,7 @@ export function SetupWizard() {
     <>
     <div className="min-h-screen bg-background flex flex-col">
       {/* Header */}
-      <div className="flex items-center px-6 md:px-10 h-14 border-b border-border/40 flex-shrink-0">
+      <div className="flex items-center px-6 md:px-10 h-14 border-b border-border/60 flex-shrink-0">
         <button
           type="button"
           onClick={handleBack}

--- a/src/components/ui/info-popover.tsx
+++ b/src/components/ui/info-popover.tsx
@@ -29,7 +29,7 @@ export function InfoPopover({ children }: InfoPopoverProps) {
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
           className={cn(
-            'z-50 w-72 rounded-xl border border-border/40 bg-card px-3 py-2 text-sm text-muted-foreground shadow-md',
+            'z-50 w-72 rounded-xl border border-border/60 bg-card px-3 py-2 text-sm text-muted-foreground shadow-md',
             'animate-in fade-in-0 zoom-in-95',
             'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
           )}

--- a/src/hooks/useUiConfig.ts
+++ b/src/hooks/useUiConfig.ts
@@ -39,33 +39,56 @@ function saveConfig(config: UiConfig) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
 }
 
+/**
+ * Clamp a primary color's lightness so it has enough contrast against
+ * the page background in both light and dark mode.
+ */
+function contrastSafeHsl(h: string, s: string, lVal: number, isDark: boolean): { hsl: string; fgIsWhite: boolean } {
+  let l = lVal;
+  if (isDark) {
+    // Too dark on a black background — boost lightness
+    if (l < 30) l = 30;
+  } else {
+    // Too light on a white background — darken
+    if (l > 60) l = 60;
+  }
+  // Foreground: white for dark primaries, black for light ones
+  const fgIsWhite = l < 55;
+  return { hsl: `${h} ${s} ${l}%`, fgIsWhite };
+}
+
 // Apply runtime CSS variable overrides based on config.
-// Slightly boosts lightness for dark mode primary (+5% L).
+// Adjusts lightness for both light and dark mode to keep contrast safe.
 function applyCssVariables(config: UiConfig) {
   if (typeof document === 'undefined') return;
   const root = document.documentElement;
   const p = config.primaryColor;
 
-  // Parse HSL to compute a slightly lighter dark-mode variant
   const parts = p.split(' ');
   if (parts.length < 3) return; // malformed value — CSS sheet defaults remain in effect
   const h = parts[0];
   const s = parts[1];
   const lVal = parseFloat(parts[2]);
-  const lDark = Math.min(lVal + 5, 100);
-  const pDark = `${h} ${s} ${lDark}%`;
 
-  // Override the CSS variables that carry the primary/accent cyan
-  // Using !important-style inline styles on :root (inline > stylesheet)
-  root.style.setProperty('--primary', p);
-  root.style.setProperty('--ring', p);
-  root.style.setProperty('--sidebar-primary', p);
-  root.style.setProperty('--sidebar-ring', p);
-  root.style.setProperty('--chart-1', p);
-  root.style.setProperty('--cyan-500', p);
+  const isDark = root.classList.contains('dark');
+  const { hsl: safePrimary, fgIsWhite } = contrastSafeHsl(h, s, lVal, isDark);
+  const primaryFg = fgIsWhite ? '0 0% 100%' : '0 0% 0%';
+
+  // Dark mode variant: slightly lighter for better visibility
+  const lDark = Math.min(lVal + 5, 100);
+  const { hsl: safePrimaryDark, fgIsWhite: fgIsWhiteDark } = contrastSafeHsl(h, s, lDark, true);
+  const primaryFgDark = fgIsWhiteDark ? '0 0% 100%' : '0 0% 0%';
+
+  // Override the CSS variables that carry the primary/accent color
+  root.style.setProperty('--primary', safePrimary);
+  root.style.setProperty('--primary-foreground', primaryFg);
+  root.style.setProperty('--ring', safePrimary);
+  root.style.setProperty('--sidebar-primary', safePrimary);
+  root.style.setProperty('--sidebar-ring', safePrimary);
+  root.style.setProperty('--chart-1', safePrimary);
+  root.style.setProperty('--cyan-500', safePrimary);
 
   // For dark mode we inject a <style> that overrides .dark with the boosted lightness.
-  // We key the element by id so we only ever have one.
   const styleId = 'sv2-primary-dark-override';
   let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
   if (!styleEl) {
@@ -73,16 +96,29 @@ function applyCssVariables(config: UiConfig) {
     styleEl.id = styleId;
     document.head.appendChild(styleEl);
   }
-  styleEl.textContent = `.dark { --primary: ${pDark}; --ring: ${pDark}; --sidebar-primary: ${pDark}; --sidebar-ring: ${pDark}; --chart-1: ${pDark}; --cyan-500: ${pDark}; }`;
+  styleEl.textContent = `.dark { --primary: ${safePrimaryDark}; --primary-foreground: ${primaryFgDark}; --ring: ${safePrimaryDark}; --sidebar-primary: ${safePrimaryDark}; --sidebar-ring: ${safePrimaryDark}; --chart-1: ${safePrimaryDark}; --cyan-500: ${safePrimaryDark}; }`;
 }
 
 export function useUiConfig() {
   const [config, setConfig] = useState<UiConfig>(() => loadConfig());
+  const [isDark, setIsDark] = useState(() =>
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+  );
+
+  // Re-apply CSS variables when theme toggles so contrast clamping updates
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const obs = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'));
+    });
+    obs.observe(document.documentElement, { attributeFilter: ['class'] });
+    return () => obs.disconnect();
+  }, []);
 
   useEffect(() => {
     applyCssVariables(config);
     saveConfig(config);
-  }, [config]);
+  }, [config, isDark]);
 
   const updateConfig = (partial: Partial<UiConfig>) => {
     setConfig((prev) => ({ ...prev, ...partial }));

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
   --background: 0 0% 100%;
   --foreground: 0 0% 9%;
 
-  --card: 0 0% 100%;
+  --card: 0 0% 99%;
   --card-foreground: 0 0% 9%;
 
   --popover: 0 0% 100%;
@@ -23,7 +23,7 @@
   --secondary: 0 0% 96%;
   --secondary-foreground: 0 0% 9%;
 
-  --muted: 0 0% 96%;
+  --muted: 0 0% 94%;
   --muted-foreground: 0 0% 45%;
 
   --accent: 190 100% 96%;
@@ -41,8 +41,8 @@
   --warning: 38 92% 50%;
   --warning-foreground: 0 0% 100%;
 
-  --border: 0 0% 92%;
-  --input: 0 0% 92%;
+  --border: 0 0% 88%;
+  --input: 0 0% 88%;
   --ring: 190 100% 45%;
 
   --radius: 0.75rem;
@@ -54,7 +54,7 @@
   --sidebar-primary-foreground: 0 0% 100%;
   --sidebar-accent: 190 100% 96%;
   --sidebar-accent-foreground: 190 100% 30%;
-  --sidebar-border: 0 0% 92%;
+  --sidebar-border: 0 0% 88%;
   --sidebar-ring: 190 100% 45%;
 
   /* Chart colors */

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -61,7 +61,7 @@ export function FAQ() {
           </div>
         </div>
 
-        <Card className="border-none shadow-md bg-gradient-to-br from-[#5865F2]/10 to-[#5865F2]/5 border-[#5865F2]/30">
+        <Card className="shadow-md bg-gradient-to-br from-[#5865F2]/10 to-[#5865F2]/5 border-[#5865F2]/30">
           <CardContent className="pt-6">
             <div className="flex flex-col sm:flex-row items-center gap-4">
               <div className="p-3 bg-[#5865F2]/10 rounded-full">
@@ -85,7 +85,7 @@ export function FAQ() {
           </CardContent>
         </Card>
 
-        <Card className="border-none shadow-md bg-card/40">
+        <Card className="shadow-md bg-card/60">
           <CardContent className="pt-6 space-y-3">
             {faqData.map((item, index) => (
               <FaqAccordionItem

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -76,7 +76,7 @@ export function Settings() {
 
           <TabsContent value="appearance">
             <div className="space-y-6 animate-in slide-in-from-bottom-2 duration-300">
-              <Card className="glass-card border-none shadow-md bg-card/40">
+              <Card className="glass-card shadow-md bg-card/60">
                 <CardHeader>
                   <CardTitle>Branding</CardTitle>
                   <CardDescription>
@@ -143,7 +143,7 @@ export function Settings() {
                     </p>
                   </div>
 
-                  <div className="flex items-center gap-4 pt-2 border-t border-border/40">
+                  <div className="flex items-center gap-4 pt-2 border-t border-border/60">
                     <Button
                       variant="outline"
                       size="sm"

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -585,7 +585,7 @@ export function UnifiedDashboard() {
 
       {/* Loading State */}
       {poolLoading && (
-        <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm p-8 text-center text-muted-foreground">
+        <div className="rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm p-8 text-center text-muted-foreground">
           Connecting to monitoring API...
         </div>
       )}
@@ -598,7 +598,7 @@ export function UnifiedDashboard() {
             <input
               type="text"
               placeholder="Search workers or connections..."
-              className="w-full pl-9 h-9 bg-muted/30 border border-border/50 focus:bg-background transition-all rounded-lg text-sm outline-none focus:ring-2 focus:ring-primary/20"
+              className="w-full pl-9 h-9 bg-muted/40 border border-border/60 focus:bg-background transition-all rounded-lg text-sm outline-none focus:ring-2 focus:ring-primary/20"
               value={searchTerm}
               onChange={(e) => {
                 setSearchTerm(e.target.value);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,9 @@ export default {
           500: 'hsl(var(--cyan-500))',
           600: 'hsl(var(--cyan-600))',
         },
+        'sv2-green': 'hsl(var(--success))',
+        'sv2-yellow': 'hsl(var(--warning))',
+        'sv2-red': 'hsl(var(--destructive))',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
closes #97 

## Body

so right now a bunch of components are basically invisible in light mode because the UI was built dark-mode-first. cards, borders, config rows, the chart - all disappear on white.

the root cause is the light mode CSS variables (--card, --border, --muted) are too close to pure white, so anything using partial opacity like bg-card/40 just produces zero contrast. this shifts them slightly darker and removes border-none from glass cards. also bumps opacity values across the board — worker tables, config rows, search bar, nav, popovers.

the other fix is for the configurable accent color. there was no contrast safety, so picking a light yellow as primary made buttons and text vanish. added lightness clamping in useUiConfig that keeps things readable in both modes.

also added missing sv2-green/yellow/red color definitions that badge variants were referencing but were never defined.

### test plan

- toggle light mode, check dashboard cards/chart/table have visible borders
- settings > appearance, pick a very light color, check buttons stay readable
- check FAQ and setup wizard borders visible in light mode
- toggle dark mode, confirm no regressions


https://github.com/user-attachments/assets/46bc9a10-547b-458c-bede-b9cacc49fa2b

