### PR TITLE
fix: show correct address placeholder for testnet4 network

### DIFF
--- a/src/components/setup/steps/JdcConfigStep.tsx
+++ b/src/components/setup/steps/JdcConfigStep.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { StepProps, JdcConfig } from '../types';
 import { Info } from 'lucide-react';
-import { isValidBitcoinAddress, getBitcoinAddressError } from '@/lib/utils';
+import { isValidBitcoinAddress, getBitcoinAddressError, getBitcoinAddressPlaceholder } from '@/lib/utils';
 
 export function JdcConfigStep({ data, updateData, onNext }: StepProps) {
   const [config, setConfig] = useState<JdcConfig>(
@@ -21,6 +21,7 @@ export function JdcConfigStep({ data, updateData, onNext }: StepProps) {
   };
 
   const network = data.bitcoin?.network ?? 'mainnet';
+  const bitcoinAddressPlaceholder = getBitcoinAddressPlaceholder(network);
 
   const isValid =
     config.user_identity.length > 0 &&
@@ -80,7 +81,7 @@ export function JdcConfigStep({ data, updateData, onNext }: StepProps) {
             type="text"
             value={config.coinbase_reward_address}
             onChange={(e) => handleChange('coinbase_reward_address', e.target.value)}
-            placeholder="bc1q..."
+            placeholder={bitcoinAddressPlaceholder}
             aria-required="true"
             autoComplete="off"
             className="w-full h-10 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"

--- a/src/components/setup/steps/MiningIdentityStep.tsx
+++ b/src/components/setup/steps/MiningIdentityStep.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { StepProps } from '../types';
 import { AlertCircle, Info } from 'lucide-react';
 import { shouldAggregateTranslatorChannels } from '../poolRules';
-import { isValidBitcoinAddress, getBitcoinAddressError } from '@/lib/utils';
+import { isValidBitcoinAddress, getBitcoinAddressError, getBitcoinAddressPlaceholder } from '@/lib/utils';
 
 const SRI_POOL_AUTHORITY_KEY = '9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72';
 
@@ -99,6 +99,7 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
   }, [finalIdentity, coinbaseAddress, isJdMode, jdcSignature, data.translator, updateData]);
 
   const network = data.bitcoin?.network ?? 'mainnet';
+  const bitcoinAddressPlaceholder = getBitcoinAddressPlaceholder(network);
   const needsAddress = donationPercent < 100;
   const requiresAddressIdentity = isSoloMode && !isJdMode;
   const identityLabel = isSoloMode
@@ -109,7 +110,7 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
   const identityPlaceholder = isSoloMode
     ? isSovereignSolo
       ? 'solo_miner'
-      : 'bc1q...'
+      : bitcoinAddressPlaceholder
     : 'username.worker1';
   const identityHelpText = isSoloMode
     ? isSovereignSolo
@@ -156,7 +157,7 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
                 type="text"
                 value={payoutAddress}
                 onChange={(e) => setPayoutAddress(e.target.value)}
-                placeholder="bc1q..."
+                placeholder={bitcoinAddressPlaceholder}
                 aria-required="true"
                 autoComplete="off"
                 className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
@@ -294,7 +295,7 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
             type="text"
             value={coinbaseAddress}
             onChange={(e) => setCoinbaseAddress(e.target.value)}
-            placeholder="bc1q..."
+            placeholder={bitcoinAddressPlaceholder}
             aria-required="true"
             autoComplete="off"
             className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"

--- a/src/components/setup/steps/TranslatorConfigStep.tsx
+++ b/src/components/setup/steps/TranslatorConfigStep.tsx
@@ -3,7 +3,7 @@ import { StepProps, TranslatorConfig } from '../types';
 import { Switch } from '@/components/ui/switch';
 import { Info } from 'lucide-react';
 import { TRANSLATOR_PORT } from '@/lib/ports';
-import { isValidBitcoinAddress, getBitcoinAddressError } from '@/lib/utils';
+import { isValidBitcoinAddress, getBitcoinAddressError, getBitcoinAddressPlaceholder } from '@/lib/utils';
 
 export function TranslatorConfigStep({ data, updateData, onNext }: StepProps) {
   const isSoloMode = data.miningMode === 'solo';
@@ -26,6 +26,7 @@ export function TranslatorConfigStep({ data, updateData, onNext }: StepProps) {
   };
 
   const network = data.bitcoin?.network ?? 'mainnet';
+  const bitcoinAddressPlaceholder = getBitcoinAddressPlaceholder(network);
 
   const isValid = isSoloMode
     ? isValidBitcoinAddress(config.user_identity, network)
@@ -40,7 +41,7 @@ export function TranslatorConfigStep({ data, updateData, onNext }: StepProps) {
 
   const getUserIdentityPlaceholder = () => {
     if (isSoloMode) {
-      return 'bc1q...';
+      return bitcoinAddressPlaceholder;
     }
     return 'username.worker1';
   };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -109,3 +109,10 @@ export function getBitcoinAddressError(addr: string, network: 'mainnet' | 'testn
   const otherNetwork = network === 'mainnet' ? 'testnet4' : 'mainnet';
   return isValidBitcoinAddress(addr, otherNetwork) ? 'Wrong network' : 'Invalid Bitcoin address';
 }
+
+/**
+ * Returns a network-specific address placeholder for form hints.
+ */
+export function getBitcoinAddressPlaceholder(network: 'mainnet' | 'testnet4'): string {
+  return network === 'mainnet' ? 'bc1q...' : 'tb1q...';
+}


### PR DESCRIPTION
## Summary

Closes #91

## Problem

- Bitcoin address input fields across the setup wizard displayed a hardcoded `bc1q...` (mainnet) placeholder regardless of the selected network
- Users on testnet4 were shown a misleading mainnet address format as the suggestion

## Changes

- Added `getBitcoinAddressPlaceholder()` utility in utils.ts that returns `bc1q...` for mainnet and `tb1q...` for testnet4
- Updated `JdcConfigStep` — coinbase reward address placeholder now reflects the selected network
- Updated `TranslatorConfigStep` — user identity placeholder in solo mode now reflects the selected network
- Updated `MiningIdentityStep` — identity, payout address, and coinbase address placeholders now reflect the selected network

## Testing

- Start the setup wizard and select **testnet4** in the Bitcoin setup step
- Navigate through JDC config, Translator config, and Mining Identity steps
- Verify all Bitcoin address placeholders show `tb1q...`
- Go back, switch to **mainnet**, and confirm placeholders show `bc1q...`