### PR TITLE
Remove ready to start section

### DIFF
--- a/src/components/setup/steps/ReviewStart.tsx
+++ b/src/components/setup/steps/ReviewStart.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { StepProps } from "../types";
-import { CheckCircle2, Loader2, AlertCircle } from "lucide-react";
+import { Loader2, AlertCircle } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { MinerConnectionInfo } from "../MinerConnectionInfo";
 import { shouldAggregateTranslatorChannels } from "../poolRules";
@@ -337,19 +337,6 @@ export function ReviewStart({ data, onComplete }: ReviewStartProps) {
               </div>
             )}
           </div>
-        </div>
-      </div>
-
-      <div className="p-4 rounded-xl bg-primary/[0.08] flex gap-3">
-        <CheckCircle2 className="h-5 w-5 text-primary flex-shrink-0 mt-0.5" />
-        <div className="text-sm">
-          <p className="font-medium text-primary mb-1">Ready to start</p>
-          <ul className="text-muted-foreground text-xs space-y-0.5 list-disc list-inside">
-            {isJdMode && <li>{isSovereignSolo ? 'Start the JD Client in sovereign solo mode' : 'Start the JD Client container'}</li>}
-            <li>Start the Translator Proxy container</li>
-            <li>{isSovereignSolo ? 'Wire the Translator to your local JDC instance' : 'Configure networking between services'}</li>
-            <li>Redirect to the monitoring dashboard</li>
-          </ul>
         </div>
       </div>
 


### PR DESCRIPTION
I don't see value of this section as it pushes technicalities users likely don't understand, and also pushes start button below the fold so on some screen sizes it's not visible to the user that they can go to the next step.

<img width="1490" height="856" alt="Screenshot 2026-04-15 at 15 06 05" src="https://github.com/user-attachments/assets/daaa4e57-0ea0-4846-8523-5759c3ad191e" />

<img width="641" height="162" alt="Screenshot 2026-04-15 at 15 05 51" src="https://github.com/user-attachments/assets/f491942d-49bf-45e2-94c0-a556616befb8" />

<img width="1507" height="856" alt="Screenshot 2026-04-15 at 15 57 01" src="https://github.com/user-attachments/assets/a72170bf-5b99-43ab-8f3e-951466657464" />

