### PR TITLE
move support page next to theme switch, redesign

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -141,7 +141,7 @@ export function Shell({
 
           {/* Desktop: nav */}
           <nav className="hidden sm:flex items-stretch h-14 gap-0 ml-2">
-            {navItems.map((item) => {
+            {navItems.filter(item => item.href !== '/faq').map((item) => {
               const isActive =
                 location === item.href ||
                 (item.href !== '/' && location.startsWith(item.href));
@@ -195,8 +195,23 @@ export function Shell({
               </>
             )}
 
-            {/* Theme toggle — desktop only (mobile: in hamburger) */}
-            <span className="hidden sm:block shrink-0"><ThemeBtn /></span>
+            {/* Support + Theme toggle — desktop only (mobile: in hamburger) */}
+            <span className="hidden sm:flex items-center gap-0.5 shrink-0">
+              <Link href="/faq">
+                <button
+                  aria-label="Support & FAQ"
+                  className={cn(
+                    'relative flex items-center justify-center rounded-full transition-all duration-150 w-7 h-7',
+                    location === '/faq' || location.startsWith('/faq')
+                      ? 'text-foreground'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-foreground/8'
+                  )}
+                >
+                  <HelpCircle className="h-[14px] w-[14px]" />
+                </button>
+              </Link>
+              <ThemeBtn />
+            </span>
 
             {/* Hamburger — mobile only */}
             <button

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -3,7 +3,7 @@ import { Shell } from '@/components/layout/Shell';
 import { Card, CardContent } from '@/components/ui/card';
 import { useConnectionStatus } from '@/hooks/useConnectionStatus';
 import { faqData, type FaqItem } from '@/data/faq-data';
-import { ChevronDown, ChevronUp, HelpCircle, MessageCircle } from 'lucide-react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 function FaqAccordionItem({ item, isOpen, onToggle }: { item: FaqItem; isOpen: boolean; onToggle: () => void }) {
@@ -37,7 +37,7 @@ function FaqAccordionItem({ item, isOpen, onToggle }: { item: FaqItem; isOpen: b
 
 export function FAQ() {
   const { status: connectionStatus, statusLabel: connectionLabel, poolName, uptime } = useConnectionStatus();
-  const [openIndex, setOpenIndex] = useState<number | null>(0);
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const handleToggle = (index: number) => {
     setOpenIndex(openIndex === index ? null : index);
@@ -51,22 +51,16 @@ export function FAQ() {
       uptime={uptime}
     >
         <div className="space-y-6 max-w-3xl">
-        <div className="flex items-center gap-3">
-          <HelpCircle className="h-8 w-8 text-primary" />
-          <div>
-            <h2 className="text-2xl font-bold tracking-tight">Support & FAQ</h2>
-            <p className="text-muted-foreground">
-              Common questions about the SV2 mining stack.
-            </p>
-          </div>
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Support & FAQ</h2>
+          <p className="text-muted-foreground">
+            Common questions about the SV2 UI.
+          </p>
         </div>
 
         <Card className="border-none shadow-md bg-gradient-to-br from-[#5865F2]/10 to-[#5865F2]/5 border-[#5865F2]/30">
           <CardContent className="pt-6">
             <div className="flex flex-col sm:flex-row items-center gap-4">
-              <div className="p-3 bg-[#5865F2]/10 rounded-full">
-                <MessageCircle className="h-8 w-8 text-[#5865F2]" />
-              </div>
               <div className="flex-1 text-center sm:text-left">
                 <h3 className="font-semibold text-lg text-foreground">Join our Community</h3>
                 <p className="text-sm text-muted-foreground">
@@ -98,17 +92,6 @@ export function FAQ() {
           </CardContent>
         </Card>
 
-        <p className="text-center text-sm text-muted-foreground">
-          Don't see your question answered?{' '}
-          <a
-            href="https://discord.com/invite/fsEW23wFYs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[#5865F2] hover:underline font-medium"
-          >
-            Reach out on Discord
-          </a>
-        </p>
       </div>
     </Shell>
   );


### PR DESCRIPTION
This PR moves support page on the right header side next to the theme switch, making it less prominent. It also removes exessive icons on support page and removes bottom text since Join discord call to action seemed too excessive with just two FAQ, we can add that text as we build the page.

I also used SV2 UI instead of SV2 Mining stack, to ensure consistency in how we call it.
Before
<img width="1282" height="746" alt="Screenshot 2026-04-15 at 23 10 57" src="https://github.com/user-attachments/assets/71f6e656-b6cb-4f48-b5c5-0003fe6bd3d7" />


After
<img width="1266" height="846" alt="Screenshot 2026-04-15 at 23 10 44" src="https://github.com/user-attachments/assets/e39c6270-b527-4eb0-8334-4c6c4faa0895" />
