### PR TITLE
fix #97

### DIFF
--- a/src/components/data/DownstreamWorkerTable.tsx
+++ b/src/components/data/DownstreamWorkerTable.tsx
@@ -38,6 +38,8 @@ interface DownstreamWorkerTableProps {
   showBestDiff?: boolean;
 }
 
+const TABLE_CONTAINER_CLASS_NAME = 'glass-table shadow-sm';
+
 function SortIcon({
   column,
   sortKey,
@@ -88,7 +90,7 @@ export function DownstreamWorkerTable({
 }: DownstreamWorkerTableProps) {
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className={TABLE_CONTAINER_CLASS_NAME}>
         <div className="p-8 text-center text-muted-foreground">
           Loading workers...
         </div>
@@ -97,7 +99,7 @@ export function DownstreamWorkerTable({
   }
 
   return (
-    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+    <div className={TABLE_CONTAINER_CLASS_NAME}>
       {workers.length === 0 ? (
         <div className="p-8 text-center text-muted-foreground">
           No workers connected
@@ -105,7 +107,7 @@ export function DownstreamWorkerTable({
       ) : (
         <Table>
           <TableHeader className="bg-muted/30">
-            <TableRow className="hover:bg-transparent border-border/40">
+            <TableRow className="hover:bg-transparent">
               <TableHead className="w-[132px] cursor-pointer select-none whitespace-nowrap" onClick={() => onSort('connection_id')}>
                 <span className="flex items-center gap-1 whitespace-nowrap hover:text-foreground transition-colors">
                   Connection Id
@@ -159,7 +161,7 @@ export function DownstreamWorkerTable({
           </TableHeader>
           <TableBody>
             {workers.map((worker) => (
-              <TableRow key={`${worker.connection_id}-${worker.channel_type}-${worker.channel_id ?? 'na'}-${worker.user_identity}`} className="hover:bg-muted/20 border-border/40 group">
+              <TableRow key={`${worker.connection_id}-${worker.channel_type}-${worker.channel_id ?? 'na'}-${worker.user_identity}`} className="hover:bg-muted/20 group">
                 <TableCell className="font-mono text-xs text-muted-foreground">
                   {worker.connection_id}
                 </TableCell>

--- a/src/components/data/HashrateChart.tsx
+++ b/src/components/data/HashrateChart.tsx
@@ -119,7 +119,7 @@ export function HashrateChart({
   // Don't render chart if no data
   if (!data || data.length === 0) {
     return (
-      <Card className="glass-card border-none shadow-sm bg-card/40">
+      <Card className="glass-card shadow-sm">
         <CardHeader>
           <div className="flex items-center justify-between">
             <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">
@@ -142,7 +142,7 @@ export function HashrateChart({
   const { domain, ticks } = getNiceYAxisScale(data.map(d => d.hashrate));
 
   return (
-    <Card className="glass-card border-none shadow-sm bg-card/40">
+    <Card className="glass-card shadow-sm">
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base font-normal text-muted-foreground flex items-center gap-1.5">

--- a/src/components/data/StatCard.tsx
+++ b/src/components/data/StatCard.tsx
@@ -30,7 +30,7 @@ export function StatCard({
   className,
 }: StatCardProps) {
   return (
-    <Card className={cn('glass-card border-none shadow-md bg-card/40', className)}>
+    <Card className={cn('glass-card shadow-md', className)}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
           {title}

--- a/src/components/data/UpstreamChannelTable.tsx
+++ b/src/components/data/UpstreamChannelTable.tsx
@@ -15,6 +15,8 @@ interface UpstreamChannelTableProps {
   isLoading?: boolean;
 }
 
+const TABLE_CONTAINER_CLASS_NAME = 'glass-table shadow-sm';
+
 /**
  * Table component for displaying upstream connection channels.
  * Shows channels to the upstream server (Pool for JDC, Pool or JDC for Translator).
@@ -26,7 +28,7 @@ export function UpstreamChannelTable({
 }: UpstreamChannelTableProps) {
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className={TABLE_CONTAINER_CLASS_NAME}>
         <div className="p-8 text-center text-muted-foreground">
           Loading channels...
         </div>
@@ -41,7 +43,7 @@ export function UpstreamChannelTable({
 
   if (allChannels.length === 0) {
     return (
-      <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+      <div className={TABLE_CONTAINER_CLASS_NAME}>
         <div className="p-8 text-center text-muted-foreground">
           No upstream channels
         </div>
@@ -50,10 +52,10 @@ export function UpstreamChannelTable({
   }
 
   return (
-    <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm overflow-hidden shadow-sm">
+    <div className={TABLE_CONTAINER_CLASS_NAME}>
       <Table>
         <TableHeader className="bg-muted/30">
-          <TableRow className="hover:bg-transparent border-border/40">
+          <TableRow className="hover:bg-transparent">
             <TableHead className="w-[80px]">Channel</TableHead>
             <TableHead>Type</TableHead>
             <TableHead>User Identity</TableHead>
@@ -66,7 +68,7 @@ export function UpstreamChannelTable({
         </TableHeader>
         <TableBody>
           {allChannels.map((channel) => (
-            <TableRow key={`${channel.type}-${channel.channel_id}`} className="hover:bg-muted/20 border-border/40">
+            <TableRow key={`${channel.type}-${channel.channel_id}`} className="hover:bg-muted/20">
               <TableCell className="font-mono text-xs">
                 {channel.channel_id}
               </TableCell>

--- a/src/components/ui/info-popover.tsx
+++ b/src/components/ui/info-popover.tsx
@@ -29,7 +29,7 @@ export function InfoPopover({ children }: InfoPopoverProps) {
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
           className={cn(
-            'z-50 w-72 rounded-xl border border-border/40 bg-card px-3 py-2 text-sm text-muted-foreground shadow-md',
+            'glass-overlay z-50 w-72 px-3 py-2 text-sm text-muted-foreground shadow-md',
             'animate-in fade-in-0 zoom-in-95',
             'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
           )}

--- a/src/hooks/useUiConfig.ts
+++ b/src/hooks/useUiConfig.ts
@@ -15,6 +15,10 @@ const DEFAULT_CONFIG: UiConfig = {
   customLogoDataUrl: '',
 };
 
+const PRIMARY_FOREGROUND_LIGHTNESS_THRESHOLD = 60;
+const LIGHT_PRIMARY_FOREGROUND = '0 0% 100%';
+const DARK_PRIMARY_FOREGROUND = '0 0% 9%';
+
 function loadConfig(): UiConfig {
   if (typeof window === 'undefined') return DEFAULT_CONFIG;
   try {
@@ -39,8 +43,15 @@ function saveConfig(config: UiConfig) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
 }
 
+function getPrimaryForeground(lightness: number): string {
+  return lightness >= PRIMARY_FOREGROUND_LIGHTNESS_THRESHOLD
+    ? DARK_PRIMARY_FOREGROUND
+    : LIGHT_PRIMARY_FOREGROUND;
+}
+
 // Apply runtime CSS variable overrides based on config.
-// Slightly boosts lightness for dark mode primary (+5% L).
+// Slightly boosts lightness for dark mode primary (+5% L) and
+// keeps foreground text readable for user-selected accent colors.
 function applyCssVariables(config: UiConfig) {
   if (typeof document === 'undefined') return;
   const root = document.documentElement;
@@ -52,14 +63,19 @@ function applyCssVariables(config: UiConfig) {
   const h = parts[0];
   const s = parts[1];
   const lVal = parseFloat(parts[2]);
+  if (Number.isNaN(lVal)) return;
   const lDark = Math.min(lVal + 5, 100);
   const pDark = `${h} ${s} ${lDark}%`;
+  const primaryForeground = getPrimaryForeground(lVal);
+  const primaryForegroundDark = getPrimaryForeground(lDark);
 
-  // Override the CSS variables that carry the primary/accent cyan
+  // Override the CSS variables that carry the user-selected primary color.
   // Using !important-style inline styles on :root (inline > stylesheet)
   root.style.setProperty('--primary', p);
+  root.style.setProperty('--primary-foreground', primaryForeground);
   root.style.setProperty('--ring', p);
   root.style.setProperty('--sidebar-primary', p);
+  root.style.setProperty('--sidebar-primary-foreground', primaryForeground);
   root.style.setProperty('--sidebar-ring', p);
   root.style.setProperty('--chart-1', p);
   root.style.setProperty('--cyan-500', p);
@@ -73,7 +89,7 @@ function applyCssVariables(config: UiConfig) {
     styleEl.id = styleId;
     document.head.appendChild(styleEl);
   }
-  styleEl.textContent = `.dark { --primary: ${pDark}; --ring: ${pDark}; --sidebar-primary: ${pDark}; --sidebar-ring: ${pDark}; --chart-1: ${pDark}; --cyan-500: ${pDark}; }`;
+  styleEl.textContent = `.dark { --primary: ${pDark}; --primary-foreground: ${primaryForegroundDark}; --ring: ${pDark}; --sidebar-primary: ${pDark}; --sidebar-primary-foreground: ${primaryForegroundDark}; --sidebar-ring: ${pDark}; --chart-1: ${pDark}; --cyan-500: ${pDark}; }`;
 }
 
 export function useUiConfig() {

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -58,7 +58,7 @@ export function FAQ() {
           </p>
         </div>
 
-        <Card className="border-none shadow-md bg-gradient-to-br from-[#5865F2]/10 to-[#5865F2]/5 border-[#5865F2]/30">
+        <Card className="shadow-md bg-gradient-to-br from-[#5865F2]/10 to-[#5865F2]/5 border-[#5865F2]/30">
           <CardContent className="pt-6">
             <div className="flex flex-col sm:flex-row items-center gap-4">
               <div className="flex-1 text-center sm:text-left">
@@ -79,7 +79,7 @@ export function FAQ() {
           </CardContent>
         </Card>
 
-        <Card className="border-none shadow-md bg-card/40">
+        <Card className="glass-card shadow-md">
           <CardContent className="pt-6 space-y-3">
             {faqData.map((item, index) => (
               <FaqAccordionItem

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -76,7 +76,7 @@ export function Settings() {
 
           <TabsContent value="appearance">
             <div className="space-y-6 animate-in slide-in-from-bottom-2 duration-300">
-              <Card className="glass-card border-none shadow-md bg-card/40">
+              <Card className="glass-card shadow-md">
                 <CardHeader>
                   <CardTitle>Branding</CardTitle>
                   <CardDescription>
@@ -143,7 +143,7 @@ export function Settings() {
                     </p>
                   </div>
 
-                  <div className="flex items-center gap-4 pt-2 border-t border-border/40">
+                  <div className="flex items-center gap-4 pt-2 border-t border-border">
                     <Button
                       variant="outline"
                       size="sm"

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -611,7 +611,7 @@ export function UnifiedDashboard() {
 
       {/* Loading State */}
       {poolLoading && (
-        <div className="rounded-xl border border-border/40 bg-card/40 backdrop-blur-sm p-8 text-center text-muted-foreground">
+        <div className="glass-table shadow-sm p-8 text-center text-muted-foreground">
           Connecting to monitoring API...
         </div>
       )}
@@ -624,7 +624,7 @@ export function UnifiedDashboard() {
             <input
               type="text"
               placeholder="Search workers or connections..."
-              className="w-full pl-9 h-9 bg-muted/30 border border-border/50 focus:bg-background transition-all rounded-lg text-sm outline-none focus:ring-2 focus:ring-primary/20"
+              className="w-full pl-9 h-9 rounded-lg border border-border bg-muted/50 text-sm outline-none transition-all focus:bg-background focus:ring-2 focus:ring-primary/20"
               value={searchTerm}
               onChange={(e) => {
                 setSearchTerm(e.target.value);
@@ -661,14 +661,14 @@ export function UnifiedDashboard() {
                 <button
                   onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
                   disabled={currentPage === 1}
-                  className="px-3 py-1.5 text-sm border border-border/50 rounded-lg hover:bg-muted/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="px-3 py-1.5 text-sm rounded-lg border border-border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
                 >
                   Previous
                 </button>
                 <button
                   onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
                   disabled={currentPage === totalPages}
-                  className="px-3 py-1.5 text-sm border border-border/50 rounded-lg hover:bg-muted/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="px-3 py-1.5 text-sm rounded-lg border border-border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
                 >
                   Next
                 </button>


### PR DESCRIPTION
. The real issue was that a lot of cards, tables, and panels in light mode were using very faint transparent backgrounds and borders, so they were basically washing out against the white page. I removed those weak overrides and leaned on the shared surface styles that already exist, which made the UI readable again without changing the look more than necessary. I also added a small safeguard for custom accent colors so button text stays readable. 

The earlier PR felt heavier because it touched more unrelated UI and solved the issue with more local tweaks, which makes the code harder to trust and maintain.

<img width="964" height="671" alt="Screenshot 2026-04-17 at 19 00 00" src="https://github.com/user-attachments/assets/602bb92d-6f43-4510-b899-e11722d3a9d8" />
<img width="997" height="620" alt="Screenshot 2026-04-17 at 19 00 16" src="https://github.com/user-attachments/assets/6643e009-62c8-4339-a716-4985f4eeb178" />


