### PR TITLE
add parser for `node.sock` problems

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -459,7 +459,7 @@ async function startJdc(
         '9091/tcp': [{ HostPort: '9091' }],
       },
       NetworkMode: NETWORK_NAME,
-      RestartPolicy: { Name: 'always' },
+      RestartPolicy: { Name: 'no' },
     },
     ExposedPorts: {
       '34265/tcp': {},

--- a/server/src/logs/parsers.test.ts
+++ b/server/src/logs/parsers.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  unknownUserParser,
+  jdcBitcoinCoreDisconnectedParser,
+} from './parsers.js';
+import type { ContainerLogLine } from './types.js';
+
+function createLogLine(
+  container: 'translator' | 'jdc',
+  message: string
+): ContainerLogLine {
+  return {
+    container,
+    stream: 'stderr',
+    timestamp: '2026-04-17T18:30:43.174887Z',
+    message,
+    raw: `2026-04-17T18:30:43.174887Z ERROR ${message}`,
+  };
+}
+
+test('unknownUserParser matches OpenMiningChannelError with unknown-user', () => {
+  const lines = [
+    createLogLine(
+      'translator',
+      'OpenMiningChannelError(request_id: 123, error_code: unknown-user)'
+    ),
+  ];
+
+  const result = unknownUserParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'unknown-user');
+  assert.equal(result?.severity, 'warning');
+  assert.equal(result?.title, 'Invalid Braiins username');
+  assert.deepEqual(result?.containers, ['translator']);
+  assert.equal(result?.evidence.length, 1);
+});
+
+test('unknownUserParser returns null when no match', () => {
+  const lines = [
+    createLogLine('translator', 'Some other error message'),
+  ];
+
+  const result = unknownUserParser(lines);
+
+  assert.equal(result, null);
+});
+
+test('unknownUserParser returns null when wrong container', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'OpenMiningChannelError(request_id: 123, error_code: unknown-user)'
+    ),
+  ];
+
+  const result = unknownUserParser(lines);
+
+  assert.equal(result, null);
+});
+
+test('jdcBitcoinCoreDisconnectedParser matches CapnpError Disconnected', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Disconnected, extra: "Peer disconnected." })'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-disconnected');
+  assert.equal(result?.severity, 'error');
+  assert.equal(result?.title, 'Bitcoin Core stopped running');
+  assert.deepEqual(result?.containers, ['jdc']);
+  assert.equal(result?.evidence.length, 1);
+});
+
+test('jdcBitcoinCoreDisconnectedParser matches Disconnected Peer disconnected', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'bitcoin_core_sv2::template_distribution_protocol::monitors: Failed to get response: Disconnected: Peer disconnected.'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-disconnected');
+  assert.equal(result?.severity, 'error');
+});
+
+test('jdcBitcoinCoreDisconnectedParser matches CannotConnectToUnixSocket', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CannotConnectToUnixSocket("/root/.bitcoin/node.sock", "Connection refused (os error 111)")'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-disconnected');
+  assert.equal(result?.severity, 'error');
+});
+
+test('jdcBitcoinCoreDisconnectedParser returns null when no match', () => {
+  const lines = [
+    createLogLine('jdc', 'Some other error message'),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.equal(result, null);
+});
+
+test('jdcBitcoinCoreDisconnectedParser returns null when wrong container', () => {
+  const lines = [
+    createLogLine(
+      'translator',
+      'Failed to create BitcoinCoreToSv2: CannotConnectToUnixSocket("/root/.bitcoin/node.sock", "Connection refused (os error 111)")'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.equal(result, null);
+});
+
+test('jdcBitcoinCoreDisconnectedParser collects multiple matches', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Disconnected, extra: "Peer disconnected." })'
+    ),
+    createLogLine(
+      'jdc',
+      'bitcoin_core_sv2::template_distribution_protocol::monitors: Failed to get response: Disconnected: Peer disconnected.'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreDisconnectedParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.evidence.length, 2);
+});

--- a/server/src/logs/parsers.ts
+++ b/server/src/logs/parsers.ts
@@ -9,6 +9,9 @@ import type {
 const UNKNOWN_USER_REGEX =
   /OpenMiningChannelError\(request_id: \d+, error_code: unknown-user\)/;
 
+const JDC_BITCOIN_CORE_DISCONNECTED_REGEX =
+  /Failed to (create BitcoinCoreToSv2|get response): (CannotConnectToUnixSocket|CapnpError\(Error \{ kind: Disconnected|Disconnected: Peer disconnected)/;
+
 function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   const matches = lines.filter(
     ({ container, message }) =>
@@ -42,10 +45,46 @@ function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   };
 }
 
+function jdcBitcoinCoreDisconnectedParser(
+  lines: ContainerLogLine[]
+): LogDiagnostic | null {
+  const matches = lines.filter(
+    ({ container, message }) =>
+      container === 'jdc' && JDC_BITCOIN_CORE_DISCONNECTED_REGEX.test(message)
+  );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const evidence: DiagnosticEvidence[] = matches.map(
+    ({ container, stream, timestamp, raw }) => ({
+      container,
+      stream,
+      timestamp,
+      line: raw,
+    })
+  );
+
+  return {
+    code: 'jdc-bitcoin-core-disconnected',
+    severity: 'error' as DiagnosticSeverity,
+    title: 'Bitcoin Core stopped running',
+    message: 'We lost connection with your Bitcoin Core node.',
+    recommendation:
+      'Make sure your Bitcoin Core node is up and running on the same computer where you’re running the sv2-ui app.',
+    streamId: 'mining-services',
+    containers: ['jdc'],
+    detectedAt: matches[0].timestamp,
+    evidence,
+  };
+}
+
 // Central registry for scenario-specific parsers. New log-derived diagnostics
 // should be added here without changing the collection pipeline.
 export const logParsers: LogParser[] = [
   { code: 'unknown-user', match: unknownUserParser },
+  { code: 'jdc-bitcoin-core-disconnected', match: jdcBitcoinCoreDisconnectedParser },
 ];
 
 function toDiagnosticsArray(

--- a/server/src/logs/parsers.ts
+++ b/server/src/logs/parsers.ts
@@ -12,7 +12,7 @@ const UNKNOWN_USER_REGEX =
 const JDC_BITCOIN_CORE_DISCONNECTED_REGEX =
   /Failed to (create BitcoinCoreToSv2|get response): (CannotConnectToUnixSocket|CapnpError\(Error \{ kind: Disconnected|Disconnected: Peer disconnected)/;
 
-function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
+export function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   const matches = lines.filter(
     ({ container, message }) =>
       container === 'translator' && UNKNOWN_USER_REGEX.test(message)
@@ -45,7 +45,7 @@ function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   };
 }
 
-function jdcBitcoinCoreDisconnectedParser(
+export function jdcBitcoinCoreDisconnectedParser(
   lines: ContainerLogLine[]
 ): LogDiagnostic | null {
   const matches = lines.filter(


### PR DESCRIPTION
closes #83 
to be merged after #90 
I changed the restart policy of the jdc container, so it don't make the message blink in the screen.

added a parser to catch scenarios where the jdc has problems with the `node.sock` connection.


<img width="2518" height="1684" alt="image" src="https://github.com/user-attachments/assets/a9b941de-f98d-413c-85b9-a35e69bbaeea" />
