### PR TITLE
validate pool authority pubkey to prevent broken TOML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run server tests
-        run: npm run test:server
+      - name: Run tests
+        run: npm run test:all
 
   typecheck:
     name: Type Check

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.62.0",
         "bitcoinjs-lib": "^7.0.1",
+        "bs58check": "^4.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build:all": "npm run build && npm run build:server",
     "preview": "vite preview",
     "lint": "eslint . --max-warnings 0",
+    "test": "node --test --import tsx src/**/*.test.ts",
     "test:server": "npm run test --prefix server",
+    "test:all": "npm run test && npm run test:server",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -25,6 +27,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.62.0",
     "bitcoinjs-lib": "^7.0.1",
+    "bs58check": "^4.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -8,6 +8,11 @@ import { PoolIcon } from '@/components/ui/pool-icon';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
 import { getPoolsForMode, type KnownPool } from '@/lib/pools';
+import {
+  getPoolAuthorityPubkeyError,
+  isValidPoolAuthorityPubkey,
+  stripWrappingQuotes,
+} from '@/lib/utils';
 import type { SetupData } from '@/components/setup/types';
 import {
   Loader2,
@@ -164,7 +169,10 @@ export function ConfigurationTab() {
     setEditIdentity('');
   };
 
-  const isPoolValid = !!editPool?.address && !!editPool?.authority_public_key;
+  const isPoolValid =
+    !!editPool?.address &&
+    !!editPool?.authority_public_key &&
+    isValidPoolAuthorityPubkey(editPool.authority_public_key);
   const isIdentityValid = editIdentity.trim().length > 0;
 
   const saveEdit = () => {
@@ -524,10 +532,15 @@ export function ConfigurationTab() {
                           id="edit-pool-pubkey"
                           type="text"
                           value={editPool?.authority_public_key ?? ''}
-                          onChange={e => setEditPool(prev => prev ? { ...prev, authority_public_key: e.target.value } : prev)}
+                          onChange={e => setEditPool(prev => prev ? { ...prev, authority_public_key: stripWrappingQuotes(e.target.value) } : prev)}
                           placeholder="Enter pool's authority public key"
                           className="w-full h-9 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
                         />
+                        {getPoolAuthorityPubkeyError(editPool?.authority_public_key ?? '') && (
+                          <p className="text-xs text-destructive mt-1">
+                            {getPoolAuthorityPubkeyError(editPool?.authority_public_key ?? '')}
+                          </p>
+                        )}
                       </div>
                     </div>
                   )}

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -9,7 +9,9 @@ import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
 import { getPoolsForMode, type KnownPool } from '@/lib/pools';
 import {
+  getIdentifierError,
   getPoolAuthorityPubkeyError,
+  isTomlSafeIdentifier,
   isValidPoolAuthorityPubkey,
   stripWrappingQuotes,
 } from '@/lib/utils';
@@ -173,7 +175,7 @@ export function ConfigurationTab() {
     !!editPool?.address &&
     !!editPool?.authority_public_key &&
     isValidPoolAuthorityPubkey(editPool.authority_public_key);
-  const isIdentityValid = editIdentity.trim().length > 0;
+  const isIdentityValid = isTomlSafeIdentifier(editIdentity);
 
   const saveEdit = () => {
     if (!config) return;
@@ -620,19 +622,24 @@ export function ConfigurationTab() {
                 disabled={editing !== null && editing !== 'identity'}
                 display={<p className="font-mono text-xs text-muted-foreground truncate">{identity}</p>}
                 editContent={
-                  <input
-                    type="text"
-                    value={editIdentity}
-                    onChange={(e) => setEditIdentity(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && isIdentityValid && !isSaving) saveEdit();
-                      if (e.key === 'Escape') cancelEdit();
-                    }}
-                    autoFocus
-                    autoComplete="off"
-                    placeholder={identityLabel}
-                    className="w-full h-10 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-                  />
+                  <div>
+                    <input
+                      type="text"
+                      value={editIdentity}
+                      onChange={(e) => setEditIdentity(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && isIdentityValid && !isSaving) saveEdit();
+                        if (e.key === 'Escape') cancelEdit();
+                      }}
+                      autoFocus
+                      autoComplete="off"
+                      placeholder={identityLabel}
+                      className="w-full h-10 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
+                    />
+                    {getIdentifierError(editIdentity) && (
+                      <p className="text-xs text-destructive mt-1">{getIdentifierError(editIdentity)}</p>
+                    )}
+                  </div>
                 }
               />
             );

--- a/src/components/setup/steps/MiningIdentityStep.tsx
+++ b/src/components/setup/steps/MiningIdentityStep.tsx
@@ -2,7 +2,13 @@ import { useState, useEffect } from 'react';
 import { StepProps } from '../types';
 import { AlertCircle, Info } from 'lucide-react';
 import { shouldAggregateTranslatorChannels } from '../poolRules';
-import { isValidBitcoinAddress, getBitcoinAddressError, getBitcoinAddressPlaceholder } from '@/lib/utils';
+import {
+  isValidBitcoinAddress,
+  getBitcoinAddressError,
+  getBitcoinAddressPlaceholder,
+  isTomlSafeIdentifier,
+  getIdentifierError,
+} from '@/lib/utils';
 
 const SRI_POOL_AUTHORITY_KEY = '9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72';
 
@@ -126,8 +132,11 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
     : 'Bitcoin address for receiving rewards during solo mining fallback';
 
   const isValid = useSriConventions
-    ? (!needsAddress || (payoutAddress.trim().length > 0 && isValidBitcoinAddress(payoutAddress.trim(), network)))
+    ? ((!needsAddress || (payoutAddress.trim().length > 0 && isValidBitcoinAddress(payoutAddress.trim(), network)))
+       && isTomlSafeIdentifier(finalIdentity)
+       && (!isJdMode || isValidBitcoinAddress(coinbaseAddress, network)))
     : (userIdentity.length > 0 &&
+       isTomlSafeIdentifier(userIdentity) &&
        (!requiresAddressIdentity || isValidBitcoinAddress(userIdentity, network)) &&
        (!isJdMode || isValidBitcoinAddress(coinbaseAddress, network)));
 
@@ -184,6 +193,9 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
               autoComplete="off"
               className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
             />
+            {workerName && getIdentifierError(workerName) && (
+              <p className="text-xs text-destructive mt-1">{getIdentifierError(workerName)}</p>
+            )}
             <p className="text-xs text-muted-foreground mt-2">
               A name to identify this mining device
             </p>
@@ -268,6 +280,9 @@ export function MiningIdentityStep({ data, updateData, onNext }: StepProps) {
             />
             {requiresAddressIdentity && getBitcoinAddressError(userIdentity, network) && (
               <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(userIdentity, network)}</p>
+            )}
+            {!requiresAddressIdentity && getIdentifierError(userIdentity) && (
+              <p className="text-xs text-destructive mt-1">{getIdentifierError(userIdentity)}</p>
             )}
             <p className="text-xs text-muted-foreground mt-2">
               {identityHelpText}

--- a/src/components/setup/steps/PoolConfigStep.tsx
+++ b/src/components/setup/steps/PoolConfigStep.tsx
@@ -3,6 +3,11 @@ import { StepProps, PoolConfig } from '../types';
 import { Check } from 'lucide-react';
 import { PoolIcon } from '@/components/ui/pool-icon';
 import { POOL_MINING_NO_JD, POOL_MINING_JD, SOLO_POOLS, type KnownPool } from '@/lib/pools';
+import {
+  getPoolAuthorityPubkeyError,
+  isValidPoolAuthorityPubkey,
+  stripWrappingQuotes,
+} from '@/lib/utils';
 
 export function PoolConfigStep({ data, updateData, onNext }: StepProps) {
   const isSoloMode = data.miningMode === 'solo';
@@ -37,7 +42,14 @@ export function PoolConfigStep({ data, updateData, onNext }: StepProps) {
   };
 
   const handleCustomChange = (field: keyof PoolConfig, value: string | number) => {
-    const updated = { ...customPool, [field]: value };
+    // Normalize the stored pubkey so the TOML writer receives a clean value.
+    // isValidPoolAuthorityPubkey also strips internally for its own robustness,
+    // but the stored value has to be unquoted independently.
+    const normalized =
+      field === 'authority_public_key' && typeof value === 'string'
+        ? stripWrappingQuotes(value)
+        : value;
+    const updated = { ...customPool, [field]: normalized };
     setCustomPool(updated);
     updateData({ pool: updated });
   };
@@ -48,7 +60,10 @@ export function PoolConfigStep({ data, updateData, onNext }: StepProps) {
     updateData({ pool: customPool });
   };
 
-  const isValid = data.pool && data.pool.address && data.pool.authority_public_key;
+  const isValid =
+    data.pool &&
+    data.pool.address &&
+    isValidPoolAuthorityPubkey(data.pool.authority_public_key);
 
   return (
     <div className="space-y-8">
@@ -182,6 +197,11 @@ export function PoolConfigStep({ data, updateData, onNext }: StepProps) {
               autoComplete="off"
               className="w-full h-10 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
             />
+            {getPoolAuthorityPubkeyError(customPool.authority_public_key) && (
+              <p className="text-xs text-destructive mt-1">
+                {getPoolAuthorityPubkeyError(customPool.authority_public_key)}
+              </p>
+            )}
             <p id="pool-pubkey-hint" className="text-xs text-muted-foreground mt-2">The pool's public key for Noise protocol authentication</p>
           </div>
         </div>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,6 +5,8 @@ import {
   stripWrappingQuotes,
   isValidPoolAuthorityPubkey,
   getPoolAuthorityPubkeyError,
+  isTomlSafeIdentifier,
+  getIdentifierError,
 } from './utils';
 
 const VALID_PUBKEYS = [
@@ -104,4 +106,64 @@ test('getPoolAuthorityPubkeyError: returns a message for a tampered-checksum pub
   const pk = VALID_PUBKEYS[0];
   const flipped = pk.slice(0, -1) + (pk.slice(-1) === 'a' ? 'b' : 'a');
   assert.match(getPoolAuthorityPubkeyError(flipped) ?? '', /invalid/i);
+});
+
+test('isTomlSafeIdentifier: accepts a plain username', () => {
+  assert.equal(isTomlSafeIdentifier('miner.worker1'), true);
+});
+
+test('isTomlSafeIdentifier: accepts an SRI-format identity with slashes', () => {
+  assert.equal(isTomlSafeIdentifier('sri/solo/bc1qexampleaddress/worker1'), true);
+});
+
+test('isTomlSafeIdentifier: rejects a value containing a double quote', () => {
+  assert.equal(isTomlSafeIdentifier('worker"1'), false);
+});
+
+test('isTomlSafeIdentifier: rejects a value containing a backslash', () => {
+  assert.equal(isTomlSafeIdentifier('worker\\1'), false);
+});
+
+test('isTomlSafeIdentifier: rejects a value containing a newline', () => {
+  assert.equal(isTomlSafeIdentifier('worker\n1'), false);
+});
+
+test('isTomlSafeIdentifier: rejects a value containing a tab', () => {
+  assert.equal(isTomlSafeIdentifier('worker\t1'), false);
+});
+
+test('isTomlSafeIdentifier: rejects a value containing a control character', () => {
+  assert.equal(isTomlSafeIdentifier('worker\x07bell'), false);
+});
+
+test('isTomlSafeIdentifier: rejects leading whitespace', () => {
+  assert.equal(isTomlSafeIdentifier(' worker1'), false);
+});
+
+test('isTomlSafeIdentifier: rejects trailing whitespace', () => {
+  assert.equal(isTomlSafeIdentifier('worker1 '), false);
+});
+
+test('isTomlSafeIdentifier: rejects an empty string', () => {
+  assert.equal(isTomlSafeIdentifier(''), false);
+});
+
+test('getIdentifierError: returns null for empty input (required-ness is enforced separately)', () => {
+  assert.equal(getIdentifierError(''), null);
+});
+
+test('getIdentifierError: returns null for a valid identifier', () => {
+  assert.equal(getIdentifierError('miner.worker1'), null);
+});
+
+test('getIdentifierError: returns a whitespace-specific message for padded input', () => {
+  assert.match(getIdentifierError(' miner ') ?? '', /whitespace/i);
+});
+
+test('getIdentifierError: returns a not-allowed-characters message for a quote', () => {
+  assert.match(getIdentifierError('mi"ner') ?? '', /not allowed|invalid|characters/i);
+});
+
+test('getIdentifierError: returns a not-allowed-characters message for a backslash', () => {
+  assert.match(getIdentifierError('mi\\ner') ?? '', /not allowed|invalid|characters/i);
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  stripWrappingQuotes,
+  isValidPoolAuthorityPubkey,
+  getPoolAuthorityPubkeyError,
+} from './utils';
+
+const VALID_PUBKEYS = [
+  '9awtMD5KQgvRUh2yFbjVeT7b6hjipWcAsQHd6wEhgtDT9soosna', // Braiins
+  '9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72', // SRI
+  '9bCoFxTszKCuffyywH5uS5o6WcU4vsjTH2axxc7wE86y2HhvULU', // Blitzpool
+];
+
+test('stripWrappingQuotes: returns the input unchanged when no wrapping quotes', () => {
+  assert.equal(stripWrappingQuotes('abc'), 'abc');
+});
+
+test('stripWrappingQuotes: trims leading and trailing whitespace', () => {
+  assert.equal(stripWrappingQuotes('  abc  '), 'abc');
+});
+
+test('stripWrappingQuotes: strips a matched pair of wrapping double quotes', () => {
+  assert.equal(stripWrappingQuotes('"abc"'), 'abc');
+});
+
+test('stripWrappingQuotes: strips a matched pair of wrapping single quotes', () => {
+  assert.equal(stripWrappingQuotes("'abc'"), 'abc');
+});
+
+test('stripWrappingQuotes: trims then strips quotes', () => {
+  assert.equal(stripWrappingQuotes('  "abc"  '), 'abc');
+});
+
+test('stripWrappingQuotes: does not strip unmatched quotes', () => {
+  assert.equal(stripWrappingQuotes('"abc'), '"abc');
+  assert.equal(stripWrappingQuotes('abc"'), 'abc"');
+});
+
+test('stripWrappingQuotes: does not strip interior quotes', () => {
+  assert.equal(stripWrappingQuotes('a"b"c'), 'a"b"c');
+});
+
+test('isValidPoolAuthorityPubkey: accepts known production pubkeys', () => {
+  for (const pk of VALID_PUBKEYS) {
+    assert.equal(isValidPoolAuthorityPubkey(pk), true, `expected ${pk} to be valid`);
+  }
+});
+
+test('isValidPoolAuthorityPubkey: accepts a pubkey wrapped in quotes (validator normalizes internally so callers do not need to strip)', () => {
+  assert.equal(isValidPoolAuthorityPubkey(`"${VALID_PUBKEYS[1]}"`), true);
+});
+
+test('isValidPoolAuthorityPubkey: accepts a pubkey with surrounding whitespace (validator trims internally)', () => {
+  assert.equal(isValidPoolAuthorityPubkey(`  ${VALID_PUBKEYS[0]}  `), true);
+});
+
+test('isValidPoolAuthorityPubkey: rejects empty string', () => {
+  assert.equal(isValidPoolAuthorityPubkey(''), false);
+});
+
+test('isValidPoolAuthorityPubkey: rejects whitespace-only string', () => {
+  assert.equal(isValidPoolAuthorityPubkey('   '), false);
+});
+
+test('isValidPoolAuthorityPubkey: rejects a pubkey with a tampered checksum (last char flipped)', () => {
+  const pk = VALID_PUBKEYS[0];
+  const flipped = pk.slice(0, -1) + (pk.slice(-1) === 'a' ? 'b' : 'a');
+  assert.equal(isValidPoolAuthorityPubkey(flipped), false);
+});
+
+test('isValidPoolAuthorityPubkey: rejects a pubkey containing a TOML-breaking interior quote', () => {
+  assert.equal(isValidPoolAuthorityPubkey('9aw"MD5KQgvRU'), false);
+});
+
+test('isValidPoolAuthorityPubkey: rejects obvious non-base58 input', () => {
+  assert.equal(isValidPoolAuthorityPubkey('not a pubkey'), false);
+});
+
+test('isValidPoolAuthorityPubkey: rejects a base58-charset string with no checksum (length too short)', () => {
+  assert.equal(isValidPoolAuthorityPubkey('9awtMD5K'), false);
+});
+
+test('getPoolAuthorityPubkeyError: returns null for empty input (required-ness is enforced separately)', () => {
+  assert.equal(getPoolAuthorityPubkeyError(''), null);
+});
+
+test('getPoolAuthorityPubkeyError: returns null for valid pubkeys', () => {
+  for (const pk of VALID_PUBKEYS) {
+    assert.equal(getPoolAuthorityPubkeyError(pk), null, `expected ${pk} to produce no error`);
+  }
+});
+
+test('getPoolAuthorityPubkeyError: returns null for a valid pubkey wrapped in quotes (validator normalizes internally)', () => {
+  assert.equal(getPoolAuthorityPubkeyError(`"${VALID_PUBKEYS[2]}"`), null);
+});
+
+test('getPoolAuthorityPubkeyError: returns a message for an invalid pubkey', () => {
+  assert.match(getPoolAuthorityPubkeyError('not-a-real-pubkey') ?? '', /invalid/i);
+});
+
+test('getPoolAuthorityPubkeyError: returns a message for a tampered-checksum pubkey', () => {
+  const pk = VALID_PUBKEYS[0];
+  const flipped = pk.slice(0, -1) + (pk.slice(-1) === 'a' ? 'b' : 'a');
+  assert.match(getPoolAuthorityPubkeyError(flipped) ?? '', /invalid/i);
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -152,3 +152,23 @@ export function getPoolAuthorityPubkeyError(v: string): string | null {
   if (!v) return null;
   return isValidPoolAuthorityPubkey(v) ? null : 'Invalid authority public key';
 }
+
+// Characters that would break a TOML basic string ("..."): the quote itself,
+// the escape character, and any C0/DEL control character.
+// eslint-disable-next-line no-control-regex
+const TOML_UNSAFE_CHARS = /["\\\u0000-\u001F\u007F]/;
+
+export function isTomlSafeIdentifier(v: string): boolean {
+  if (!v) return false;
+  if (v !== v.trim()) return false;
+  return !TOML_UNSAFE_CHARS.test(v);
+}
+
+export function getIdentifierError(v: string): string | null {
+  if (!v) return null;
+  if (v !== v.trim()) return 'Leading or trailing whitespace is not allowed';
+  if (TOML_UNSAFE_CHARS.test(v)) {
+    return 'Contains characters that are not allowed (quotes, backslashes, control characters)';
+  }
+  return null;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from 'tiny-secp256k1';
+import bs58check from 'bs58check';
 
 // Required for taproot (P2TR) address validation
 bitcoin.initEccLib(ecc);
@@ -115,4 +116,39 @@ export function getBitcoinAddressError(addr: string, network: 'mainnet' | 'testn
  */
 export function getBitcoinAddressPlaceholder(network: 'mainnet' | 'testnet4'): string {
   return network === 'mainnet' ? 'bc1q...' : 'tb1q...';
+}
+
+// Pubkeys in pool docs / Discord are almost always shown wrapped in quotes,
+// and users copy them with the quotes. Strip one matched pair, then trim.
+export function stripWrappingQuotes(v: string): string {
+  const trimmed = v.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+// The SRI Noise-protocol authority key is base58check-encoded, so a corrupted
+// character or missing byte fails the checksum — which is exactly what
+// copy-paste mistakes produce. Wrapping quotes (the dominant mistake from
+// docs/Discord) are stripped here so the caller does not have to remember to
+// normalize before calling.
+export function isValidPoolAuthorityPubkey(v: string): boolean {
+  const normalized = stripWrappingQuotes(v);
+  if (!normalized) return false;
+  try {
+    bs58check.decode(normalized);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getPoolAuthorityPubkeyError(v: string): string | null {
+  if (!v) return null;
+  return isValidPoolAuthorityPubkey(v) ? null : 'Invalid authority public key';
 }


### PR DESCRIPTION
## Body

Closes #113.

Pool authority pubkeys in the SRI docs and Discord channels are almost always shown wrapped in quotes, and users copy them with the quotes. The wizard dropped that value verbatim into a TOML basic string, producing invalid TOML and a silent container crash loop.

Fix is input-time validation mirroring how Bitcoin addresses are already validated (per @GitGab19 and @lucasbalieiro's note that this field is base58check). `bs58check.decodeUnsafe` catches both charset errors and checksum failures, which is what copy-paste corruption looks like. Wrapping quotes get stripped on every update so the dominant paste case becomes a zero-click fix; the validator itself stays strict and rejects anything still quoted or whitespace-padded. Same treatment for `user_identity` - rejects `"`, `\`, and control characters that would break TOML.

Bootstraps vitest for `src/` and covers the validators with 40 unit tests: every preset pubkey, wrapping-quote paste, tampered checksum, and each individual TOML-unsafe character. Verified manually: pasted quoted Braiins key, quotes stripped on entry, made it through to the review page cleanly.