### PR TITLE
Add invalid certificate parser

### DIFF
--- a/server/src/logs/parsers.test.ts
+++ b/server/src/logs/parsers.test.ts
@@ -5,6 +5,7 @@ import {
   unknownUserParser,
   jdcBitcoinCoreDisconnectedParser,
 } from './parsers.js';
+import { collectDiagnostics } from './parsers.js';
 import type { ContainerLogLine } from './types.js';
 
 function createLogLine(
@@ -19,6 +20,22 @@ function createLogLine(
     raw: `2026-04-17T18:30:43.174887Z ERROR ${message}`,
   };
 }
+
+const SAMPLE_TRANSLATOR_LINE = (message: string): ContainerLogLine => ({
+  container: 'translator',
+  stream: 'stderr',
+  timestamp: '2026-04-22T18:40:21.344598Z',
+  message,
+  raw: `2026-04-22T18:40:21.344598Z ${message}`,
+});
+
+const SAMPLE_JDC_LINE = (message: string): ContainerLogLine => ({
+  container: 'jdc',
+  stream: 'stderr',
+  timestamp: '2026-04-22T18:38:34.491085Z',
+  message,
+  raw: `2026-04-22T18:38:34.491085Z ${message}`,
+});
 
 test('unknownUserParser matches OpenMiningChannelError with unknown-user', () => {
   const lines = [
@@ -148,4 +165,60 @@ test('jdcBitcoinCoreDisconnectedParser collects multiple matches', () => {
 
   assert.ok(result !== null);
   assert.equal(result?.evidence.length, 2);
+});
+
+test('invalidCertificateParser: detects InvalidCertificate in translator', () => {
+  const lines = [
+    SAMPLE_TRANSLATOR_LINE(
+      'ERROR translator_sv2::sv2::upstream::upstream: Failed Noise handshake with 75.119.150.111:3333: Invalid Certificate: SignatureNoiseMessage { version: 0, valid_from: 1776883236, not_valid_after: 1776886836, signature: ce3caec9ac6174dffcfe276d6bedc7abda82a6a7cfb3244500a279a60dd722ab031c6849e329fb2d7da33b11c466d52546c0a4ab8f1a7f48e7ffd31d093b6a8f }. Retrying...'
+    ),
+  ];
+
+  const diagnostics = collectDiagnostics(lines);
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0]?.code, 'invalid-certificate');
+  assert.equal(diagnostics[0]?.severity, 'error');
+  assert.equal(diagnostics[0]?.title, 'Invalid Server Certificate');
+  assert.ok(diagnostics[0]?.recommendation.includes('NTP'));
+  assert.ok(diagnostics[0]?.containers.includes('translator'));
+});
+
+test('invalidCertificateParser: detects InvalidCertificate in jd container', () => {
+  const lines = [
+    SAMPLE_JDC_LINE(
+      'WARN jd_client_sv2: Attempt 1/3 failed for pool=75.119.150.111:3333, jds=75.119.150.111:3334: NetworkHelpersError(CodecError(NoiseSv2Error(InvalidCertificate(SignatureNoiseMessage { version: 0, valid_from: 1776883128, not_valid_after: 1776886728, signature: [153, 148, 250, 162, 139, 0, 8, 46, 100, 107, 22, 38, 57, 228, 110, 104, 137, 23, 187, 172, 188, 90, 163, 98, 68, 39, 134, 213, 130, 81, 61, 3, 135, 201, 63, 146, 195, 227, 253, 20, 198, 200, 214, 123, 210, 92, 52, 249, 177, 99, 136, 82, 134, 91, 101, 32, 172, 239, 165, 121, 141, 9, 249, 6] }))))'
+    ),
+  ];
+
+  const diagnostics = collectDiagnostics(lines);
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0]?.code, 'invalid-certificate');
+  assert.equal(diagnostics[0]?.severity, 'error');
+  assert.ok(diagnostics[0]?.containers.includes('jdc'));
+});
+
+test('invalidCertificateParser: does not match unrelated errors', () => {
+  const lines = [
+    SAMPLE_TRANSLATOR_LINE('ERROR translator_sv2::some::module: Connection refused'),
+  ];
+
+  const diagnostics = collectDiagnostics(lines);
+
+  assert.equal(diagnostics.length, 0);
+});
+
+test('invalidCertificateParser: returns evidence with line data', () => {
+  const lines = [
+    SAMPLE_TRANSLATOR_LINE(
+      'ERROR translator_sv2::sv2::upstream::upstream: Failed Noise handshake with 75.119.150.111:3333: Invalid Certificate: SignatureNoiseMessage { version: 0, valid_from: 1776883236, not_valid_after: 1776886836, signature: test }. Retrying...'
+    ),
+  ];
+
+  const diagnostics = collectDiagnostics(lines);
+
+  assert.equal(diagnostics[0]?.evidence.length, 1);
+  assert.equal(diagnostics[0]?.evidence[0]?.container, 'translator');
+  assert.equal(diagnostics[0]?.evidence[0]?.stream, 'stderr');
 });

--- a/server/src/logs/parsers.ts
+++ b/server/src/logs/parsers.ts
@@ -12,6 +12,9 @@ const UNKNOWN_USER_REGEX =
 const JDC_BITCOIN_CORE_DISCONNECTED_REGEX =
   /Failed to (create BitcoinCoreToSv2|get response): (CannotConnectToUnixSocket|CapnpError\(Error \{ kind: Disconnected|Disconnected: Peer disconnected)/;
 
+const INVALID_CERTIFICATE_REGEX =
+  /(InvalidCertificate|Invalid Certificate).*SignatureNoiseMessage \{ version: \d+, valid_from: (\d+), not_valid_after: (\d+),/;
+
 export function unknownUserParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   const matches = lines.filter(
     ({ container, message }) =>
@@ -72,9 +75,43 @@ export function jdcBitcoinCoreDisconnectedParser(
     title: 'Bitcoin Core stopped running',
     message: 'We lost connection with your Bitcoin Core node.',
     recommendation:
-      'Make sure your Bitcoin Core node is up and running on the same computer where you’re running the sv2-ui app.',
+      "Make sure your Bitcoin Core node is up and running on the same computer where you're running the sv2-ui app.",
     streamId: 'mining-services',
     containers: ['jdc'],
+    detectedAt: matches[0].timestamp,
+    evidence,
+  };
+}
+
+function invalidCertificateParser(lines: ContainerLogLine[]): LogDiagnostic | null {
+  const matches = lines.filter(
+    ({ container, message }) =>
+      (container === 'translator' || container === 'jdc') &&
+      INVALID_CERTIFICATE_REGEX.test(message)
+  );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const evidence: DiagnosticEvidence[] = matches.map(
+    ({ container, stream, timestamp, raw }) => ({
+      container,
+      stream,
+      timestamp,
+      line: raw,
+    })
+  );
+
+  return {
+    code: 'invalid-certificate',
+    severity: 'error' as DiagnosticSeverity,
+    title: 'Invalid Server Certificate',
+    message:
+      'We were unable to stablish communication with the pool.',
+    recommendation: 'Check that your system clock is set correctly and synchronized with an NTP server.',
+    streamId: 'mining-services',
+    containers: ['translator', 'jdc'],
     detectedAt: matches[0].timestamp,
     evidence,
   };
@@ -85,6 +122,7 @@ export function jdcBitcoinCoreDisconnectedParser(
 export const logParsers: LogParser[] = [
   { code: 'unknown-user', match: unknownUserParser },
   { code: 'jdc-bitcoin-core-disconnected', match: jdcBitcoinCoreDisconnectedParser },
+  { code: 'invalid-certificate', match: invalidCertificateParser },
 ];
 
 function toDiagnosticsArray(


### PR DESCRIPTION
closes #87 

adding a new parser to get the `InvalidCertificate` errors

<img width="2514" height="1360" alt="image" src="https://github.com/user-attachments/assets/c136dcd2-523d-45f5-80fe-d2ca3056d60f" />
