### PR TITLE
remove leftover sovereign-solo entry from solo pool list

### DIFF
--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -59,15 +59,6 @@ export const SOLO_POOLS: KnownPool[] = [
     description: 'Solo mining pool by Blitzpool',
     logoUrl: '/blitzpool.svg',
   },
-  {
-    id: 'sovereign-solo',
-    name: 'Sovereign Solo Mining',
-    address: '',
-    port: 3333,
-    authority_public_key: '',
-    description: 'Use your node to create your block template without connecting to a solo pool',
-    badge: 'coming-soon',
-  },
 ];
 
 /**


### PR DESCRIPTION


## Body



just removes the `sovereign-solo` entry from `SOLO_POOLS` in `src/lib/pools.ts`.

a few things i checked to make sure it's safe:

- grepped for `pool.id === 'sovereign-solo'` anywhere in the codebase, no hits
- the `isSovereignSolo` flag in the rest of the codebase is derived from `miningMode === 'solo' && templateMode === 'jd'`, not from this entry, so removing it doesn't touch any of that
- `computeSteps()` in `SetupWizard.tsx` already skips the pool step entirely when the user picks solo + jd (lines 54-65), so this entry was only ever showing up in the solo + no-jd path, where offering "sovereign solo" as a third pool option didn't really line up with anything anyway
- the entry had an empty `address` and empty `authority_public_key` plus a `coming-soon` badge, so it wasn't actually getting users anywhere if they did pick it

**tested locally:**

- typecheck, lint, build, all 36 tests green
- walked the wizard end to end. solo + custom templates now shows only SRI Community Solo Pool and Blitzpool. solo + sovereign still routes past the pool step into bitcoin-prereq. settings page renders fine.


https://github.com/user-attachments/assets/83d4261b-10ea-459e-9490-dc4e6e26a716



closes #124