### PR TITLE
enable backward compatibility with older versions of Bitcoin Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,18 @@ sv2-ui/
 
 ## Docker Images Used
 
-- `stratumv2/translator_sv2:main` - Translator Proxy
-- `stratumv2/jd_client_sv2:main` - JD Client
+`sv2-ui` selects the JDC and Translator Proxy images from the Bitcoin Core compatibility table.
+
+## Bitcoin Core Compatibility
+
+| Bitcoin Core | JDC image | Translator Proxy image | Status | Reference |
+|--------------|-----------|------------------------|--------|-----------|
+| 30.2 | `stratumv2/jd_client_sv2:v0.3.5` | `stratumv2/translator_sv2:v0.3.5` | Supported | [`release/v0.1.4`](https://github.com/stratum-mining/sv2-ui/tree/release/v0.1.4) |
+| 31.0 | `stratumv2/jd_client_sv2:main` | `stratumv2/translator_sv2:main` | Supported using development images | Release branches pin matching sv2-apps release tags |
+
+## Compatibility Notes
+
+- [Monitoring API compatibility](docs/monitoring-api-compatibility.md) - How `sv2-ui` should handle monitoring API changes across supported JDC and Translator Proxy image sets.
 
 ## Ports
 

--- a/docs/monitoring-api-compatibility.md
+++ b/docs/monitoring-api-compatibility.md
@@ -1,0 +1,61 @@
+# Monitoring API Compatibility
+
+`sv2-ui` consumes monitoring APIs exposed by `sv2-apps` containers, currently JD Client (JDC) and Translator Proxy (tProxy).
+
+These APIs may still be considered unstable on the `sv2-apps` side. Because of that, `sv2-ui` must not assume that every supported `sv2-apps` image exposes the same raw monitoring schema.
+
+This matters especially because `sv2-ui` may intentionally run older JDC/tProxy images when users are running older Bitcoin Core versions. For example, a user on Bitcoin Core 30.2 may require an older JDC image, while a user on Bitcoin Core 31.0 may require a newer one. Both setups may need to be supported by the same `sv2-ui` release.
+
+## Compatibility Profiles
+
+`sv2-ui` should select `sv2-apps` image versions through runtime compatibility profiles.
+
+Each profile should describe:
+
+- supported Bitcoin Core version/range
+- JDC image tag
+- Translator Proxy image tag
+- expected monitoring API contract for each app
+- optional monitoring features available for that image set
+
+## Handling API Changes
+
+When `sv2-apps` changes a monitoring API, `sv2-ui` should classify the change before updating the dashboard.
+
+### Backward-Compatible Additions
+
+Examples:
+
+- new optional field
+- new endpoint
+- new optional detail beside an existing field
+
+Action in `sv2-ui`:
+
+- no change if unused
+- optional UI enhancement if useful
+- field-presence check is usually enough
+
+### Breaking Changes
+
+Examples:
+
+- field removed
+- field renamed
+- field type changed
+- field meaning or unit changed
+- endpoint removed or response shape changed
+
+Action in `sv2-ui`:
+
+- update the compatibility profile for the affected image
+- add or update backend normalization if the frontend needs a stable shape
+- add fixture tests using payloads from the affected image versions
+
+## Frontend Rule
+
+The React frontend should avoid depending on version-specific raw JDC/tProxy response shapes when multiple supported images differ.
+
+If a raw API difference affects data already shown by the dashboard, normalize it in the `sv2-ui` backend or shared monitoring layer first.
+
+If a future image exposes new monitoring data that older images do not have, treat it as an optional feature and render it only for compatible profiles.

--- a/server/src/compatibility.ts
+++ b/server/src/compatibility.ts
@@ -1,0 +1,74 @@
+import type { SetupData } from './types.js';
+
+export type BitcoinCoreVersion = '30.2' | '31.0';
+
+export type CompatibilityProfileId =
+  | 'bitcoin-core-30.2'
+  | 'bitcoin-core-31.0';
+
+export interface CompatibilityProfile {
+  id: CompatibilityProfileId;
+  bitcoinCoreVersion: BitcoinCoreVersion;
+  status: 'supported';
+  images: {
+    jdc: string;
+    translator: string;
+  };
+  monitoringApi: {
+    jdc: string;
+    translator: string;
+  };
+}
+
+export const COMPATIBILITY_PROFILES: Record<BitcoinCoreVersion, CompatibilityProfile> = {
+  '30.2': {
+    id: 'bitcoin-core-30.2',
+    bitcoinCoreVersion: '30.2',
+    status: 'supported',
+    images: {
+      jdc: 'stratumv2/jd_client_sv2:v0.3.5',
+      translator: 'stratumv2/translator_sv2:v0.3.5',
+    },
+    monitoringApi: {
+      jdc: '/api/v1',
+      translator: '/api/v1',
+    },
+  },
+  '31.0': {
+    id: 'bitcoin-core-31.0',
+    bitcoinCoreVersion: '31.0',
+    status: 'supported',
+    images: {
+      // Development uses the latest sv2-apps images. Release branches must
+      // replace these with the matching published sv2-apps release tags.
+      jdc: 'stratumv2/jd_client_sv2:main',
+      translator: 'stratumv2/translator_sv2:main',
+    },
+    monitoringApi: {
+      jdc: '/api/v1',
+      translator: '/api/v1',
+    },
+  },
+} as const;
+
+export function isSupportedBitcoinCoreVersion(
+  version: string | null | undefined
+): version is BitcoinCoreVersion {
+  return version === '30.2' || version === '31.0';
+}
+
+export function getCompatibilityProfileForBitcoinCore(
+  version: string | null | undefined
+): CompatibilityProfile {
+  if (!isSupportedBitcoinCoreVersion(version)) {
+    throw new Error(
+      'Unsupported or missing Bitcoin Core version. Select Bitcoin Core 30.2 or 31.0 before starting the stack.'
+    );
+  }
+
+  return COMPATIBILITY_PROFILES[version];
+}
+
+export function getCompatibilityProfileForSetup(data: SetupData): CompatibilityProfile {
+  return getCompatibilityProfileForBitcoinCore(data.bitcoin?.core_version);
+}

--- a/server/src/config-generator.ts
+++ b/server/src/config-generator.ts
@@ -61,7 +61,9 @@ function positiveInteger(value: number | undefined, fallback: number): number {
 }
 
 export function normalizeSetupData(data: SetupData): SetupData {
-  if (!data.translator) return data;
+  if (!data.translator) {
+    return data;
+  }
 
   return {
     ...data,

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -7,6 +7,7 @@ import Docker from 'dockerode';
 import os from 'os';
 import type { SetupData, ContainerStatus, HealthStatus } from './types.js';
 import type { ContainerLogLine, LogContainerRole, LogOutputStream } from './logs/types.js';
+import { getCompatibilityProfileForSetup } from './compatibility.js';
 
 /**
  * Expand ~ to home directory in a path.
@@ -145,8 +146,6 @@ const NETWORK_NAME = 'sv2-network';
 const CONFIG_VOLUME = 'sv2-config';
 const TRANSLATOR_CONTAINER = 'sv2-translator';
 const JDC_CONTAINER = 'sv2-jdc';
-const TRANSLATOR_IMAGE = 'stratumv2/translator_sv2:main';
-const JDC_IMAGE = 'stratumv2/jd_client_sv2:main';
 const DOCKER_LOG_HEADER_SIZE = 8;
 
 /**
@@ -385,7 +384,7 @@ async function getContainerStatus(name: string): Promise<ContainerStatus | null>
  * - In Docker: uses shared volume (sv2-config) for config
  * - In dev: bind-mounts config file from host filesystem
  */
-async function startTranslator(configPath: string): Promise<void> {
+async function startTranslator(configPath: string, image: string): Promise<void> {
   await removeContainer(TRANSLATOR_CONTAINER);
 
   const binds = isRunningInDocker
@@ -393,7 +392,7 @@ async function startTranslator(configPath: string): Promise<void> {
     : [`${configPath}:/config/translator.toml:ro`];
 
   const container = await docker.createContainer({
-    Image: TRANSLATOR_IMAGE,
+    Image: image,
     name: TRANSLATOR_CONTAINER,
     Entrypoint: ['/app/translator_sv2'],
     Cmd: ['-c', '/config/translator.toml'],
@@ -425,7 +424,8 @@ async function startTranslator(configPath: string): Promise<void> {
 async function startJdc(
   configPath: string,
   bitcoinSocketPath: string,
-  network: string
+  network: string,
+  image: string
 ): Promise<void> {
   await removeContainer(JDC_CONTAINER);
 
@@ -447,7 +447,7 @@ async function startJdc(
     ];
 
   const container = await docker.createContainer({
-    Image: JDC_IMAGE,
+    Image: image,
     name: JDC_CONTAINER,
     Entrypoint: ['/app/jd_client_sv2'],
     Cmd: ['-c', '/config/jdc.toml'],
@@ -486,22 +486,27 @@ export async function startStack(
   // Connect sv2-ui to the network so it can proxy API requests
   await connectSv2UiToNetwork();
 
-  // Pull latest images from Docker Hub
-  await pullImage(TRANSLATOR_IMAGE);
+  const profile = getCompatibilityProfileForSetup(data);
+  console.log(
+    `Using compatibility profile ${profile.id} for Bitcoin Core ${profile.bitcoinCoreVersion}`
+  );
+
+  // Pull profile-selected images from Docker Hub
+  await pullImage(profile.images.translator);
   if (data.mode === 'jd') {
-    await pullImage(JDC_IMAGE);
+    await pullImage(profile.images.jdc);
   }
 
   // Start JDC first if in JD mode (Translator connects to JDC)
   if (data.mode === 'jd' && data.bitcoin) {
     const socketPath = expandHomePath(data.bitcoin.socket_path);
-    await startJdc(`${configDir}/jdc.toml`, socketPath, data.bitcoin.network);
+    await startJdc(`${configDir}/jdc.toml`, socketPath, data.bitcoin.network, profile.images.jdc);
     console.log('Waiting for JDC to initialize...');
     await new Promise(resolve => setTimeout(resolve, 3000));
   }
 
   // Start Translator
-  await startTranslator(`${configDir}/translator.toml`);
+  await startTranslator(`${configDir}/translator.toml`, profile.images.translator);
 }
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url';
 
 import type { SetupData, StatusResponse, SetupResponse } from './types.js';
 import { generateTranslatorConfig, generateJdcConfig, normalizeSetupData } from './config-generator.js';
+import { isSupportedBitcoinCoreVersion } from './compatibility.js';
 import {
   startStack,
   stopStack,
@@ -68,6 +69,18 @@ async function saveState(data: SetupData): Promise<void> {
     mode: data.mode,
     data,
   }, null, 2));
+}
+
+function getBitcoinCoreVersionError(data: SetupData): string | null {
+  if (data.mode !== 'jd') {
+    return null;
+  }
+
+  if (!isSupportedBitcoinCoreVersion(data.bitcoin?.core_version)) {
+    return 'Select a supported Bitcoin Core version: 30.2 or 31.0';
+  }
+
+  return null;
 }
 
 /**
@@ -219,6 +232,11 @@ app.put('/api/config', async (req, res) => {
       return res.status(400).json({ success: false, error: 'JD mode requires JDC and Bitcoin configuration' });
     }
 
+    const bitcoinCoreVersionError = getBitcoinCoreVersionError(newData);
+    if (bitcoinCoreVersionError) {
+      return res.status(400).json({ success: false, error: bitcoinCoreVersionError });
+    }
+
     await ensureDockerAvailable();
 
     await fs.mkdir(CONFIG_DIR, { recursive: true });
@@ -343,6 +361,11 @@ app.post('/api/setup', async (req, res) => {
       return res.status(400).json({ success: false, error: 'JD mode requires JDC and Bitcoin configuration' });
     }
 
+    const bitcoinCoreVersionError = getBitcoinCoreVersionError(data);
+    if (bitcoinCoreVersionError) {
+      return res.status(400).json({ success: false, error: bitcoinCoreVersionError });
+    }
+
     await ensureDockerAvailable();
 
     // Generate config files
@@ -427,6 +450,11 @@ app.post('/api/restart', async (_req, res) => {
     const state = await loadState();
     if (!state.configured || !state.data) {
       return res.status(400).json({ success: false, error: 'Not configured' });
+    }
+
+    const bitcoinCoreVersionError = getBitcoinCoreVersionError(state.data);
+    if (bitcoinCoreVersionError) {
+      return res.status(400).json({ success: false, error: bitcoinCoreVersionError });
     }
 
     await stopStack();

--- a/server/src/logs/parsers.test.ts
+++ b/server/src/logs/parsers.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   unknownUserParser,
   jdcBitcoinCoreDisconnectedParser,
+  jdcBitcoinCoreUnsupportedMiningInterfaceParser,
 } from './parsers.js';
 import { collectDiagnostics } from './parsers.js';
 import type { ContainerLogLine } from './types.js';
@@ -165,6 +166,84 @@ test('jdcBitcoinCoreDisconnectedParser collects multiple matches', () => {
 
   assert.ok(result !== null);
   assert.equal(result?.evidence.length, 2);
+});
+
+test('jdcBitcoinCoreUnsupportedMiningInterfaceParser matches old mining interface error', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Failed, extra: "remote exception: std::exception: Old mining interface (@2) not supported. Please update your client!" })'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreUnsupportedMiningInterfaceParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-unsupported-mining-interface');
+  assert.equal(result?.severity, 'error');
+  assert.equal(result?.title, 'Bitcoin Core version does not match');
+  assert.deepEqual(result?.containers, ['jdc']);
+  assert.equal(result?.evidence.length, 1);
+  assert.equal(result?.recommendation, 'Open setup and select your actual Bitcoin Core version.');
+});
+
+test('jdcBitcoinCoreUnsupportedMiningInterfaceParser matches old mining interface error in shorter log lines', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'ERROR bitcoin_core_sv2: remote exception: std::exception: Old mining interface (@0xabc123) not supported. Please update your client!'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreUnsupportedMiningInterfaceParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-unsupported-mining-interface');
+  assert.equal(result?.evidence.length, 1);
+});
+
+test('jdcBitcoinCoreUnsupportedMiningInterfaceParser matches unimplemented Bitcoin Core IPC method', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'ERROR jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Unimplemented, extra: "remote exception: Method not implemented.; interfaceName = capnp/init.capnp:Init; typeId = 9815814193794562661; methodId = 3" })'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreUnsupportedMiningInterfaceParser(lines);
+
+  assert.ok(result !== null);
+  assert.equal(result?.code, 'jdc-bitcoin-core-unsupported-mining-interface');
+  assert.equal(result?.severity, 'error');
+  assert.equal(result?.evidence.length, 1);
+});
+
+test('jdcBitcoinCoreUnsupportedMiningInterfaceParser returns null for wrong container', () => {
+  const lines = [
+    createLogLine(
+      'translator',
+      'Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Failed, extra: "remote exception: std::exception: Old mining interface (@2) not supported. Please update your client!" })'
+    ),
+  ];
+
+  const result = jdcBitcoinCoreUnsupportedMiningInterfaceParser(lines);
+
+  assert.equal(result, null);
+});
+
+test('collectDiagnostics includes Bitcoin Core version mismatch diagnostics', () => {
+  const lines = [
+    createLogLine(
+      'jdc',
+      'jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CapnpError(Error { kind: Failed, extra: "remote exception: std::exception: Old mining interface (@2) not supported. Please update your client!" })'
+    ),
+  ];
+
+  const diagnostics = collectDiagnostics(lines);
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0]?.code, 'jdc-bitcoin-core-unsupported-mining-interface');
+  assert.equal(diagnostics[0]?.message, 'The Bitcoin Core version selected in setup does not match the node that is running.');
 });
 
 test('invalidCertificateParser: detects InvalidCertificate in translator', () => {

--- a/server/src/logs/parsers.ts
+++ b/server/src/logs/parsers.ts
@@ -12,6 +12,9 @@ const UNKNOWN_USER_REGEX =
 const JDC_BITCOIN_CORE_DISCONNECTED_REGEX =
   /Failed to (create BitcoinCoreToSv2|get response): (CannotConnectToUnixSocket|CapnpError\(Error \{ kind: Disconnected|Disconnected: Peer disconnected)/;
 
+const JDC_BITCOIN_CORE_UNSUPPORTED_MINING_INTERFACE_REGEX =
+  /(Old mining interface \(@[^)]+\) not supported\. Please update your client!|Failed to create BitcoinCoreToSv2: CapnpError\(Error \{ kind: Unimplemented, extra: "remote exception: Method not implemented\.; interfaceName = capnp\/init\.capnp:Init; typeId = \d+; methodId = \d+" \}\))/;
+
 const INVALID_CERTIFICATE_REGEX =
   /(InvalidCertificate|Invalid Certificate).*SignatureNoiseMessage \{ version: \d+, valid_from: (\d+), not_valid_after: (\d+),/;
 
@@ -83,6 +86,42 @@ export function jdcBitcoinCoreDisconnectedParser(
   };
 }
 
+export function jdcBitcoinCoreUnsupportedMiningInterfaceParser(
+  lines: ContainerLogLine[]
+): LogDiagnostic | null {
+  const matches = lines.filter(
+    ({ container, message }) =>
+      container === 'jdc' && JDC_BITCOIN_CORE_UNSUPPORTED_MINING_INTERFACE_REGEX.test(message)
+  );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const evidence: DiagnosticEvidence[] = matches.map(
+    ({ container, stream, timestamp, raw }) => ({
+      container,
+      stream,
+      timestamp,
+      line: raw,
+    })
+  );
+
+  return {
+    code: 'jdc-bitcoin-core-unsupported-mining-interface',
+    severity: 'error' as DiagnosticSeverity,
+    title: 'Bitcoin Core version does not match',
+    message:
+      'The Bitcoin Core version selected in setup does not match the node that is running.',
+    recommendation:
+      'Open setup and select your actual Bitcoin Core version.',
+    streamId: 'mining-services',
+    containers: ['jdc'],
+    detectedAt: matches[0].timestamp,
+    evidence,
+  };
+}
+
 function invalidCertificateParser(lines: ContainerLogLine[]): LogDiagnostic | null {
   const matches = lines.filter(
     ({ container, message }) =>
@@ -122,6 +161,10 @@ function invalidCertificateParser(lines: ContainerLogLine[]): LogDiagnostic | nu
 export const logParsers: LogParser[] = [
   { code: 'unknown-user', match: unknownUserParser },
   { code: 'jdc-bitcoin-core-disconnected', match: jdcBitcoinCoreDisconnectedParser },
+  {
+    code: 'jdc-bitcoin-core-unsupported-mining-interface',
+    match: jdcBitcoinCoreUnsupportedMiningInterfaceParser,
+  },
   { code: 'invalid-certificate', match: invalidCertificateParser },
 ];
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -13,8 +13,10 @@ export interface PoolConfig {
 }
 
 export type OperatingSystem = 'linux' | 'macos';
+export type BitcoinCoreVersion = '30.2' | '31.0';
 
 export interface BitcoinConfig {
+  core_version: BitcoinCoreVersion | null;
   network: 'mainnet' | 'testnet4';
   os: OperatingSystem;
   customDataDir: string;

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -832,6 +832,7 @@ export function ConfigurationTab() {
             <div className="p-4 rounded-lg border border-border/50 bg-muted/20 space-y-2">
               <div className="flex items-center gap-2">
                 <p className="font-medium">Bitcoin Core</p>
+                <Badge variant="outline" className="text-xs">{config.bitcoin.core_version ?? 'Not selected'}</Badge>
                 <Badge variant="outline" className="text-xs">{config.bitcoin.network}</Badge>
               </div>
               <p className="text-muted-foreground font-mono text-xs truncate">

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -77,6 +77,8 @@ function computeSteps(data: SetupData): SetupStep[] {
 }
 
 const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
+const BITCOIN_CORE_VERSION_MISMATCH_NOTICE =
+  'Bitcoin Core version mismatch detected. Select the version your running node is actually using.';
 
 export function SetupWizard() {
   const { isDark, toggle } = useTheme();
@@ -85,6 +87,7 @@ export function SetupWizard() {
   const [data, setData] = useState<SetupData>(initialSetupData);
   const [isReconfiguring, setIsReconfiguring] = useState(false);
   const [loadingConfig, setLoadingConfig] = useState(true);
+  const [bitcoinSetupNotice, setBitcoinSetupNotice] = useState<string | null>(null);
   // White flash: 0 = invisible, 1 = full white
   const [flashOpacity, setFlashOpacity] = useState(0);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -95,11 +98,25 @@ export function SetupWizard() {
   useEffect(() => {
     getCurrentConfig().then(config => {
       if (config) {
-        setData(config);
+        let nextConfig = config;
         setIsReconfiguring(true);
 
         const targetStep = window.sessionStorage.getItem(SETUP_TARGET_STEP_STORAGE_KEY) as SetupStep | null;
         window.sessionStorage.removeItem(SETUP_TARGET_STEP_STORAGE_KEY);
+
+        if (targetStep === 'bitcoin' && config.bitcoin) {
+          nextConfig = {
+            ...config,
+            bitcoin: {
+              ...config.bitcoin,
+              core_version: null,
+            },
+          };
+          setBitcoinSetupNotice(BITCOIN_CORE_VERSION_MISMATCH_NOTICE);
+        }
+
+        setData(nextConfig);
+        dataRef.current = nextConfig;
 
         if (targetStep && computeSteps(config).includes(targetStep)) {
           setCurrentStep(targetStep);
@@ -259,7 +276,13 @@ export function SetupWizard() {
             {currentStep === 'template-mode'  && <TemplateModeSelection {...stepProps} />}
             {currentStep === 'pool'            && <PoolConfigStep {...stepProps} />}
             {currentStep === 'bitcoin-prereq'  && <BitcoinPrereqStep {...stepProps} />}
-            {currentStep === 'bitcoin'         && <BitcoinSetup {...stepProps} />}
+            {currentStep === 'bitcoin'         && (
+              <BitcoinSetup
+                {...stepProps}
+                notice={bitcoinSetupNotice}
+                onDismissNotice={() => setBitcoinSetupNotice(null)}
+              />
+            )}
             {currentStep === 'hashrate'        && <HashrateStep {...stepProps} />}
             {currentStep === 'identity'        && <MiningIdentityStep {...stepProps} />}
             {currentStep === 'review'          && <ReviewStart {...stepProps} onComplete={handleComplete} />}

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -76,6 +76,8 @@ function computeSteps(data: SetupData): SetupStep[] {
   return steps;
 }
 
+const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
+
 export function SetupWizard() {
   const { isDark, toggle } = useTheme();
   const [, navigate] = useLocation();
@@ -92,7 +94,17 @@ export function SetupWizard() {
 
   useEffect(() => {
     getCurrentConfig().then(config => {
-      if (config) { setData(config); setIsReconfiguring(true); }
+      if (config) {
+        setData(config);
+        setIsReconfiguring(true);
+
+        const targetStep = window.sessionStorage.getItem(SETUP_TARGET_STEP_STORAGE_KEY) as SetupStep | null;
+        window.sessionStorage.removeItem(SETUP_TARGET_STEP_STORAGE_KEY);
+
+        if (targetStep && computeSteps(config).includes(targetStep)) {
+          setCurrentStep(targetStep);
+        }
+      }
       setLoadingConfig(false);
     });
   }, []);

--- a/src/components/setup/steps/BitcoinPrereqStep.tsx
+++ b/src/components/setup/steps/BitcoinPrereqStep.tsx
@@ -31,7 +31,7 @@ export function BitcoinPrereqStep({ onNext }: StepProps) {
           Start Bitcoin Core
         </h2>
         <p className="text-lg text-muted-foreground">
-          Job Declaration requires Bitcoin Core v30.2+ running with IPC enabled
+          Job Declaration requires Bitcoin Core 30.2 or 31.0 running with IPC enabled
         </p>
         <p className="text-sm text-muted-foreground mt-3">
           Bitcoin Core IPC is currently supported on Linux and macOS only. Windows is not supported yet.
@@ -44,10 +44,10 @@ export function BitcoinPrereqStep({ onNext }: StepProps) {
           <div className="w-7 h-7 rounded-full bg-primary/10 text-primary text-xs flex items-center justify-center font-mono flex-shrink-0 mt-0.5">1</div>
           <div className="flex-1 min-w-0">
             <div className="font-medium text-sm mb-1">
-              Install Bitcoin Core v30.2+
+              Install a supported Bitcoin Core release
             </div>
             <p className="text-xs text-muted-foreground mb-2">
-              Download the latest release with IPC support.
+              Use Bitcoin Core 30.2 or 31.0. If your node runs another version, upgrade to a supported release to get all SV2 features.
             </p>
             <a
               href="https://bitcoincore.org/en/download/"

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -17,7 +17,12 @@ function computeSocketPath(os: OperatingSystem, network: 'mainnet' | 'testnet4',
 
 const SUPPORTED_BITCOIN_CORE_VERSIONS: BitcoinCoreVersion[] = ['30.2', '31.0'];
 
-export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
+interface BitcoinSetupProps extends StepProps {
+  notice?: string | null;
+  onDismissNotice?: () => void;
+}
+
+export function BitcoinSetup({ data, updateData, onNext, notice, onDismissNotice }: BitcoinSetupProps) {
   const [coreVersion, setCoreVersion] = useState<BitcoinCoreVersion | null>(data.bitcoin?.core_version ?? null);
   const [os, setOs] = useState<OperatingSystem>(data.bitcoin?.os || 'linux');
   const [network, setNetwork] = useState<'mainnet' | 'testnet4'>(data.bitcoin?.network || 'mainnet');
@@ -95,10 +100,23 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
         <label htmlFor="core-version" className="block text-sm font-medium mb-3">
           Bitcoin Core Version
         </label>
+        {notice && (
+          <div
+            className="mb-3 p-3 rounded-lg bg-destructive/[0.08] text-sm text-destructive flex gap-3 items-start"
+            role="alert"
+            aria-live="assertive"
+          >
+            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <span>{notice}</span>
+          </div>
+        )}
         <select
           id="core-version"
           value={coreVersion ?? ''}
-          onChange={(e) => setCoreVersion(e.target.value ? (e.target.value as BitcoinCoreVersion) : null)}
+          onChange={(e) => {
+            setCoreVersion(e.target.value ? (e.target.value as BitcoinCoreVersion) : null);
+            onDismissNotice?.();
+          }}
           className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
         >
           <option value="" disabled>Select a supported version</option>

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { StepProps, BitcoinConfig, OperatingSystem } from '../types';
+import { StepProps, BitcoinConfig, BitcoinCoreVersion, OperatingSystem } from '../types';
 import { Bitcoin, Apple, Terminal, Pencil, Check, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useBitcoinSocketValidation } from '@/hooks/useBitcoinSocketValidation';
 
@@ -15,7 +15,10 @@ function computeSocketPath(os: OperatingSystem, network: 'mainnet' | 'testnet4',
   return network === 'mainnet' ? `${dataDir}/node.sock` : `${dataDir}/testnet4/node.sock`;
 }
 
+const SUPPORTED_BITCOIN_CORE_VERSIONS: BitcoinCoreVersion[] = ['30.2', '31.0'];
+
 export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
+  const [coreVersion, setCoreVersion] = useState<BitcoinCoreVersion | null>(data.bitcoin?.core_version ?? null);
   const [os, setOs] = useState<OperatingSystem>(data.bitcoin?.os || 'linux');
   const [network, setNetwork] = useState<'mainnet' | 'testnet4'>(data.bitcoin?.network || 'mainnet');
   const [customDataDir, setCustomDataDir] = useState(data.bitcoin?.customDataDir || '');
@@ -25,8 +28,16 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
   const socketPath = manualSocketPath || computedSocketPath;
 
   useEffect(() => {
-    updateData({ bitcoin: { os, network, customDataDir, socket_path: socketPath } as BitcoinConfig });
-  }, [os, network, customDataDir, socketPath, updateData]);
+    updateData({
+      bitcoin: {
+        core_version: coreVersion,
+        os,
+        network,
+        customDataDir,
+        socket_path: socketPath,
+      } as BitcoinConfig,
+    });
+  }, [coreVersion, os, network, customDataDir, socketPath, updateData]);
 
   const { isChecking, isValid, error: socketError } = useBitcoinSocketValidation(socketPath);
 
@@ -78,6 +89,33 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
         <p className="text-xs text-muted-foreground mt-2">
           Windows is intentionally omitted here because Bitcoin Core IPC support is still in progress.
         </p>
+      </div>
+
+      <div>
+        <label htmlFor="core-version" className="block text-sm font-medium mb-3">
+          Bitcoin Core Version
+        </label>
+        <select
+          id="core-version"
+          value={coreVersion ?? ''}
+          onChange={(e) => setCoreVersion(e.target.value ? (e.target.value as BitcoinCoreVersion) : null)}
+          className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
+        >
+          <option value="" disabled>Select a supported version</option>
+          {SUPPORTED_BITCOIN_CORE_VERSIONS.map((version) => (
+            <option key={version} value={version}>
+              Bitcoin Core {version}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground mt-2">
+          If your node runs another Bitcoin Core version, upgrade to a supported release to get all SV2 features.
+        </p>
+        {!coreVersion && (
+          <p className="text-xs text-destructive mt-2">
+            Select your Bitcoin Core version to continue.
+          </p>
+        )}
       </div>
 
       <div role="group" aria-labelledby="network-label">
@@ -194,7 +232,7 @@ export function BitcoinSetup({ data, updateData, onNext }: StepProps) {
         <button
           type="button"
           onClick={onNext}
-          disabled={!isChecking && !!socketError}
+          disabled={!coreVersion || (!isChecking && !!socketError)}
           className="h-11 px-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Continue

--- a/src/components/setup/steps/ReviewStart.tsx
+++ b/src/components/setup/steps/ReviewStart.tsx
@@ -220,6 +220,7 @@ export function ReviewStart({ data, onComplete }: ReviewStartProps) {
           <div className="p-5 border-x border-b border-border bg-card">
             <SectionLabel n={nextSection()} label="Bitcoin Core" />
             <div className="text-sm text-muted-foreground space-y-1 pl-7">
+              <div>Bitcoin Core {data.bitcoin.core_version ?? "Not selected"}</div>
               <div>{data.bitcoin.network}</div>
               <div className="font-mono text-xs truncate">
                 {data.bitcoin.socket_path}

--- a/src/components/setup/types.ts
+++ b/src/components/setup/types.ts
@@ -13,8 +13,10 @@ export interface PoolConfig {
 }
 
 export type OperatingSystem = 'linux' | 'macos';
+export type BitcoinCoreVersion = '30.2' | '31.0';
 
 export interface BitcoinConfig {
+  core_version: BitcoinCoreVersion | null;
   network: 'mainnet' | 'testnet4';
   os: OperatingSystem;
   customDataDir: string;

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'wouter';
 import { AlertTriangle, Search, Play } from 'lucide-react';
 import { InfoPopover } from '@/components/ui/info-popover';
 import { MinerConnectionInfo } from '@/components/setup/MinerConnectionInfo';
@@ -37,6 +38,7 @@ const RANGE_DESCRIPTIONS: Record<TimeRange, string> = {
   '15m': 'Last 15 minutes · sampled every 5 seconds',
   '1h': 'Last hour · sampled every 5 seconds',
 };
+const BITCOIN_CORE_VERSION_MISMATCH_CODE = 'jdc-bitcoin-core-unsupported-mining-interface';
 
 function normalizeUserIdentity(userIdentity: string) {
   return userIdentity.trim().toLowerCase();
@@ -515,25 +517,39 @@ export function UnifiedDashboard() {
       )}
 
       {/* log-derived Diagnostic Banners */}
-      {diagnostics.map((diagnostic) => (
-        <div
-          key={diagnostic.code}
-          className={`flex items-start gap-3 rounded-xl border px-5 py-4 text-sm ${
-            diagnostic.severity === 'error'
-              ? 'border-red-500/40 bg-red-500/10 text-red-500'
-              : 'border-amber-500/40 bg-amber-500/10 text-amber-500'
-          }`}
-        >
-          <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-          <div className="flex flex-col gap-1">
-            <span className="font-medium">{diagnostic.title}</span>
-            <span>{diagnostic.message}</span>
-            {diagnostic.recommendation && (
-              <span className="text-current/80">{diagnostic.recommendation}</span>
+      {diagnostics.map((diagnostic) => {
+        const showReconfigureButton = diagnostic.code === BITCOIN_CORE_VERSION_MISMATCH_CODE;
+
+        return (
+          <div
+            key={diagnostic.code}
+            className={`flex flex-col gap-3 rounded-xl border px-5 py-4 text-sm sm:flex-row sm:items-center sm:justify-between ${
+              diagnostic.severity === 'error'
+                ? 'border-red-500/40 bg-red-500/10 text-red-500'
+                : 'border-amber-500/40 bg-amber-500/10 text-amber-500'
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">{diagnostic.title}</span>
+                <span>{diagnostic.message}</span>
+                {diagnostic.recommendation && (
+                  <span className="text-current/80">{diagnostic.recommendation}</span>
+                )}
+              </div>
+            </div>
+            {showReconfigureButton && (
+              <Link
+                href="/setup"
+                className="inline-flex h-9 shrink-0 items-center justify-center rounded-full bg-red-500 px-4 font-medium text-white transition-colors hover:bg-red-600 sm:ml-4"
+              >
+                Reconfigure
+              </Link>
             )}
           </div>
-        </div>
-      ))}
+        );
+      })}
 
       {/* Hero Stats Section */}
       <div className={isSovereignSolo ? 'grid gap-4 md:grid-cols-2 lg:grid-cols-4' : 'grid gap-4 md:grid-cols-2 lg:grid-cols-5'}>

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -39,6 +39,7 @@ const RANGE_DESCRIPTIONS: Record<TimeRange, string> = {
   '1h': 'Last hour · sampled every 5 seconds',
 };
 const BITCOIN_CORE_VERSION_MISMATCH_CODE = 'jdc-bitcoin-core-unsupported-mining-interface';
+const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
 
 function normalizeUserIdentity(userIdentity: string) {
   return userIdentity.trim().toLowerCase();
@@ -542,6 +543,7 @@ export function UnifiedDashboard() {
             {showReconfigureButton && (
               <Link
                 href="/setup"
+                onClick={() => window.sessionStorage.setItem(SETUP_TARGET_STEP_STORAGE_KEY, 'bitcoin')}
                 className="inline-flex h-9 shrink-0 items-center justify-center rounded-full bg-red-500 px-4 font-medium text-white transition-colors hover:bg-red-600 sm:ml-4"
               >
                 Reconfigure


### PR DESCRIPTION
This PR introduces compatibility with older versions of Bitcoin Core.

The setup flow now asks users to explicitly select their Bitcoin Core version, and the backend uses that selection to choose matching JDC and tProxy Docker image tags. 

Closes #116 
~~Blocked by https://github.com/stratum-mining/sv2-apps/pull/439~~