### PR TITLE
show `shares_rejected_by_reason`  in the UI

### DIFF
--- a/src/components/ui/info-popover.tsx
+++ b/src/components/ui/info-popover.tsx
@@ -5,9 +5,11 @@ import { cn } from '@/lib/utils';
 
 interface InfoPopoverProps {
   children: React.ReactNode;
+  className?: string;
+  ariaLabel?: string;
 }
 
-export function InfoPopover({ children }: InfoPopoverProps) {
+export function InfoPopover({ children, className, ariaLabel = 'More information' }: InfoPopoverProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -15,7 +17,7 @@ export function InfoPopover({ children }: InfoPopoverProps) {
       <Popover.Trigger asChild>
         <button
           className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="More information"
+          aria-label={ariaLabel}
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
           onClick={() => setOpen(prev => !prev)}
@@ -32,6 +34,7 @@ export function InfoPopover({ children }: InfoPopoverProps) {
             'glass-overlay z-50 w-72 px-3 py-2 text-sm text-muted-foreground shadow-md',
             'animate-in fade-in-0 zoom-in-95',
             'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
+            className,
           )}
         >
           {children}

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -28,7 +28,7 @@ import { isAggregatedTproxyPoolName } from '@/components/setup/poolRules';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useConnectionStatus } from '@/hooks/useConnectionStatus';
 import { useLogDiagnostics } from '@/hooks/useLogDiagnostics';
-import { formatHashrate, formatDifficulty } from '@/lib/utils';
+import { formatHashrate, formatDifficulty, formatNumber } from '@/lib/utils';
 import type { Sv1ClientInfo } from '@/types/api';
 
 const RANGE_MS: Record<TimeRange, number> = { '5m': 5 * 60_000, '15m': 15 * 60_000, '1h': 60 * 60_000 };
@@ -342,7 +342,13 @@ export function UnifiedDashboard() {
   // Shares data from upstream SERVER channels (shares sent TO the Pool)
   const shareStats = useMemo(() => {
     if (!serverChannels) {
-      return { acknowledged: 0, submitted: 0, rejected: 0 };
+      return {
+        acknowledged: 0,
+        submitted: 0,
+        rejected: 0,
+        rejectionReasons: [],
+        unclassifiedRejected: 0,
+      };
     }
     
     const extAcknowledged = serverChannels.extended_channels.reduce((sum, ch) => sum + ch.shares_acknowledged, 0);
@@ -353,11 +359,26 @@ export function UnifiedDashboard() {
 
     const extRejected = serverChannels.extended_channels.reduce((sum, ch) => sum + ch.shares_rejected, 0);
     const stdRejected = serverChannels.standard_channels.reduce((sum, ch) => sum + ch.shares_rejected, 0);
+    const rejectedByReason = new Map<string, number>();
+    const channels = [...serverChannels.extended_channels, ...serverChannels.standard_channels];
+
+    for (const channel of channels) {
+      for (const [reason, count] of Object.entries(channel.shares_rejected_by_reason ?? {})) {
+        rejectedByReason.set(reason, (rejectedByReason.get(reason) ?? 0) + count);
+      }
+    }
+
+    const rejectionReasons = [...rejectedByReason.entries()]
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+    const classifiedRejected = rejectionReasons.reduce((sum, item) => sum + item.count, 0);
     
     return {
       acknowledged: extAcknowledged + stdAcknowledged,
       submitted: extSubmitted + stdSubmitted,
       rejected: extRejected + stdRejected,
+      rejectionReasons,
+      unclassifiedRejected: Math.max(0, extRejected + stdRejected - classifiedRejected),
     };
   }, [serverChannels]);
   const blocksFound = usePersistentBlocksFound(blocksFoundEntries, historyConfigKey);
@@ -553,6 +574,61 @@ export function UnifiedDashboard() {
         {!isSovereignSolo && (
           <StatCard
             title="Share Acceptance"
+            info={
+              shareStats.rejected > 0 ? (
+                <InfoPopover
+                  ariaLabel="Share rejection details"
+                  className="w-96 max-w-[calc(100vw-2rem)]"
+                >
+                  <div className="space-y-3">
+                    <div>
+                      <p className="font-medium text-foreground">Rejection details</p>
+                      <p className="mt-1 text-xs">
+                        SubmitSharesError error-code counts reported by the upstream channel
+                        monitoring API.
+                      </p>
+                    </div>
+
+                    {shareStats.rejectionReasons.length > 0 ? (
+                      <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                        {shareStats.rejectionReasons.map(({ reason, count }) => {
+                          const percentage = (count / shareStats.rejected) * 100;
+                          return (
+                            <div key={reason} className="rounded-lg bg-muted/45 px-3 py-2">
+                              <div className="flex items-start justify-between gap-3 text-xs">
+                                <span className="min-w-0 break-all font-mono text-foreground">
+                                  {reason}
+                                </span>
+                                <span className="shrink-0 whitespace-nowrap font-mono text-muted-foreground">
+                                  {formatNumber(count)} · {percentage.toFixed(1)}%
+                                </span>
+                              </div>
+                            </div>
+                          );
+                        })}
+                        {shareStats.unclassifiedRejected > 0 && (
+                          <div className="rounded-lg bg-muted/45 px-3 py-2">
+                            <div className="flex items-start justify-between gap-3 text-xs">
+                              <span className="min-w-0 break-all font-mono text-foreground">
+                                unknown
+                              </span>
+                              <span className="shrink-0 whitespace-nowrap font-mono text-muted-foreground">
+                                {formatNumber(shareStats.unclassifiedRejected)}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <p className="rounded-lg bg-muted/45 px-3 py-2 text-xs">
+                        This sv2-apps image reports rejected shares, but not rejection-code counts
+                        yet.
+                      </p>
+                    )}
+                  </div>
+                </InfoPopover>
+              ) : undefined
+            }
             value={(() => {
               const { submitted, rejected } = shareStats;
               if (submitted === 0) return <span className="text-muted-foreground">—</span>;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -23,6 +23,7 @@ export interface ServerExtendedChannelInfo {
   shares_acknowledged: number;
   shares_submitted: number;
   shares_rejected: number;
+  shares_rejected_by_reason?: Record<string, number>;
   share_work_sum: number;
   best_diff: number;
   blocks_found: number;
@@ -40,6 +41,7 @@ export interface ServerStandardChannelInfo {
   shares_acknowledged: number;
   shares_submitted: number;
   shares_rejected: number;
+  shares_rejected_by_reason?: Record<string, number>;
   share_work_sum: number;
   best_diff: number;
   blocks_found: number;


### PR DESCRIPTION
Closes #93 

Screenshot of the result, with a a hover/click info icon near the `Share Acceptance` title which shows the details in case of rejections:
<img width="2556" height="604" alt="Screenshot From 2026-04-29 20-41-43" src="https://github.com/user-attachments/assets/719d860c-1007-495f-83b2-4a6bafea733a" />

A way for which you can trigger the share rejections is the following:
- clone https://github.com/stratum-mining/sv2-apps
- modify `pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs` to slightly change (and break) every share which receives during share validation, with this diff:
```
diff --git a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
index a373bcac..5ee99269 100644
--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -707,10 +707,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
     async fn handle_submit_shares_extended(
         &mut self,
         client_id: Option<usize>,
-        msg: SubmitSharesExtended<'_>,
+        mut msg: SubmitSharesExtended<'_>,
         tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         info!("Received SubmitSharesExtended: {msg}");
+        msg.nonce = 0;
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 ```
- launch the Pool
- launch `sv2-ui` as usual with `npm run dev`
- configure it in SOLO POOL mode, configuring the custom (local) pool
- connect a miner and wait for the first share to arrive