### PR TITLE
fix: keep Best Diff column visible on small screens

### DIFF
--- a/src/components/data/DownstreamWorkerTable.tsx
+++ b/src/components/data/DownstreamWorkerTable.tsx
@@ -149,7 +149,7 @@ export function DownstreamWorkerTable({
               </TableHead>
               {showBestDiff && (
                 <TableHead
-                  className="hidden lg:table-cell text-right cursor-pointer select-none"
+                  className="text-right cursor-pointer select-none whitespace-nowrap"
                   onClick={() => onSort('best_diff')}
                 >
                   <span className="flex items-center justify-end gap-1 hover:text-foreground transition-colors">
@@ -185,7 +185,7 @@ export function DownstreamWorkerTable({
                   {worker.estimated_hashrate !== null ? `~${formatHashrate(worker.estimated_hashrate)}` : '-'}
                 </TableCell>
                 {showBestDiff && (
-                  <TableCell className="hidden lg:table-cell text-right font-mono text-muted-foreground">
+                  <TableCell className="text-right font-mono text-muted-foreground whitespace-nowrap">
                     {worker.best_diff !== null && worker.best_diff > 0 ? formatDifficulty(worker.best_diff) : '-'}
                   </TableCell>
                 )}

--- a/src/components/data/UpstreamChannelTable.tsx
+++ b/src/components/data/UpstreamChannelTable.tsx
@@ -61,7 +61,7 @@ export function UpstreamChannelTable({
             <TableHead>User Identity</TableHead>
             <TableHead className="text-right">Hashrate</TableHead>
             <TableHead className="text-right">Shares</TableHead>
-            <TableHead className="text-right hidden md:table-cell">Best Diff</TableHead>
+            <TableHead className="text-right whitespace-nowrap">Best Diff</TableHead>
             <TableHead className="hidden lg:table-cell">Target</TableHead>
             <TableHead className="hidden xl:table-cell">Version Rolling</TableHead>
           </TableRow>
@@ -90,7 +90,7 @@ export function UpstreamChannelTable({
               <TableCell className="text-right font-mono">
                 {formatNumber(channel.shares_acknowledged)}
               </TableCell>
-              <TableCell className="text-right font-mono hidden md:table-cell text-muted-foreground">
+              <TableCell className="text-right font-mono text-muted-foreground whitespace-nowrap">
                 {formatDifficulty(channel.best_diff)}
               </TableCell>
               <TableCell className="hidden lg:table-cell font-mono text-xs text-muted-foreground">


### PR DESCRIPTION
Fix #142 

Fixes the mobile/tablet layout issue where the “Best Diff” column was hidden below 1024px. The column is now always rendered in both the downstream workers table and the upstream channels table, and whitespace-nowrap prevents the header/value from wrapping, keeping the column readable at narrow widths. This ensures the column remains visible and scrollable on small screens instead of disappearing.