### PR TITLE
fix `node.sock` detection from docker

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -159,6 +159,144 @@ export function getDockerConnectionInfo(): DockerConnectionConfig {
   return dockerConnection;
 }
 
+export function isRunningInsideDocker(): boolean {
+  return isRunningInDocker;
+}
+
+export type BitcoinSocketValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+async function getCurrentContainerImage(): Promise<string> {
+  const configuredImage = process.env.SV2_UI_VALIDATOR_IMAGE?.trim();
+  if (configuredImage) {
+    return configuredImage;
+  }
+
+  try {
+    const self = await docker.getContainer(os.hostname()).inspect();
+    if (self.Config?.Image) {
+      return self.Config.Image;
+    }
+  } catch (error) {
+    console.warn('Could not inspect sv2-ui container image for socket validation:', error);
+  }
+
+  return 'stratumv2/sv2-ui:latest';
+}
+
+const BITCOIN_SOCKET_VALIDATOR_SCRIPT = `
+const net = require('net');
+
+const socketPath = process.argv[1];
+const timeoutMs = Number(process.argv[2] || 1000);
+const displayPath = process.argv[3] || socketPath;
+const socket = net.createConnection({ path: socketPath });
+let settled = false;
+
+function finish(ok, message) {
+  if (settled) return;
+  settled = true;
+  socket.destroy();
+  if (!ok && message) console.error(message);
+  process.exit(ok ? 0 : 1);
+}
+
+socket.setTimeout(timeoutMs);
+socket.once('connect', () => finish(true));
+socket.once('timeout', () => finish(false, 'Socket did not respond within ' + timeoutMs + 'ms. Bitcoin Core may be unresponsive.'));
+socket.once('error', (err) => {
+  switch (err.code) {
+    case 'ENOENT':
+      finish(false, 'Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
+      break;
+    case 'ECONNREFUSED':
+      finish(false, 'Socket file exists at ' + displayPath + ' but nothing is listening. Bitcoin Core may have crashed or been stopped.');
+      break;
+    case 'EACCES':
+      finish(false, 'Permission denied for ' + displayPath + '. Check that the sv2-ui process can read this file.');
+      break;
+    case 'ENOTSOCK':
+      finish(false, 'Path ' + displayPath + ' is not a Unix socket.');
+      break;
+    default:
+      finish(false, err.message || 'Unknown error connecting to socket');
+  }
+});
+`;
+
+/**
+ * When sv2-ui runs in Docker, host paths such as ~/.bitcoin/node.sock are not
+ * visible inside the sv2-ui container. Validate the socket through Docker by
+ * bind-mounting the host socket into a short-lived helper container.
+ */
+export async function probeHostBitcoinSocketWithDocker(
+  socketPath: string,
+  timeoutMs = 1000
+): Promise<BitcoinSocketValidationResult> {
+  refreshDockerConnection();
+
+  const helperSocketPath = '/tmp/sv2-bitcoin-node.sock';
+  let container: Docker.Container | null = null;
+
+  try {
+    const image = await getCurrentContainerImage();
+    container = await docker.createContainer({
+      Image: image,
+      Entrypoint: ['node'],
+      Cmd: ['-e', BITCOIN_SOCKET_VALIDATOR_SCRIPT, helperSocketPath, String(timeoutMs), socketPath],
+      AttachStdout: true,
+      AttachStderr: true,
+      HostConfig: {
+        NetworkMode: 'none',
+        Mounts: [
+          {
+            Type: 'bind',
+            Source: socketPath,
+            Target: helperSocketPath,
+            ReadOnly: true,
+          },
+        ],
+        RestartPolicy: { Name: 'no' },
+      },
+    });
+
+    await container.start();
+    const result = await container.wait();
+
+    if (result.StatusCode === 0) {
+      return { valid: true };
+    }
+
+    const rawLogs = await container.logs({ stdout: true, stderr: true });
+    const message = demuxDockerLogBuffer(Buffer.isBuffer(rawLogs) ? rawLogs : Buffer.from(rawLogs))
+      .map((chunk) => chunk.payload.trim())
+      .filter(Boolean)
+      .join('\n');
+
+    return {
+      valid: false,
+      error: message || `Socket validation failed for ${socketPath}`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      valid: false,
+      error: message.includes('bind source path does not exist')
+        ? `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`
+        : message,
+    };
+  } finally {
+    if (container) {
+      try {
+        await container.remove({ force: true });
+      } catch {
+        // Best effort cleanup for short-lived validation containers.
+      }
+    }
+  }
+}
+
 const LOG_CONTAINER_NAMES: Record<LogContainerRole, string> = {
   translator: TRANSLATOR_CONTAINER,
   jdc: JDC_CONTAINER,

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -5,6 +5,7 @@
 import fs from 'fs';
 import Docker from 'dockerode';
 import os from 'os';
+import path from 'path';
 import type { SetupData, ContainerStatus, HealthStatus } from './types.js';
 import type { ContainerLogLine, LogContainerRole, LogOutputStream } from './logs/types.js';
 import { getImageSelectionForSetup } from './compatibility.js';
@@ -167,6 +168,10 @@ export type BitcoinSocketValidationResult =
   | { valid: true }
   | { valid: false; error: string };
 
+type BitcoinSocketValidationOptions = {
+  network?: 'mainnet' | 'testnet4';
+};
+
 async function getCurrentContainerImage(): Promise<string> {
   const configuredImage = process.env.SV2_UI_VALIDATOR_IMAGE?.trim();
   if (configuredImage) {
@@ -203,8 +208,26 @@ function finish(ok, message) {
 }
 
 socket.setTimeout(timeoutMs);
-socket.once('connect', () => finish(true));
-socket.once('timeout', () => finish(false, 'Socket did not respond within ' + timeoutMs + 'ms. Bitcoin Core may be unresponsive.'));
+socket.once('connect', () => {
+  // Docker Desktop on macOS can report a successful connect for stale
+  // bind-mounted Unix sockets. Bitcoin Core's IPC server sends a
+  // libmultiprocess/Cap'n Proto "Peer disconnected" response when the client
+  // immediately closes the write side, which proves a real IPC process replied.
+  socket.end();
+});
+socket.once('data', (chunk) => {
+  const response = chunk.toString('utf8');
+  if (/peer disconnected/i.test(response)) {
+    finish(true);
+    return;
+  }
+
+  finish(false, 'Socket responded at ' + displayPath + ', but it did not look like Bitcoin Core IPC.');
+});
+socket.once('close', () => {
+  finish(false, 'Socket did not respond with Bitcoin Core IPC data at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
+});
+socket.once('timeout', () => finish(false, 'Socket did not respond with Bitcoin Core IPC data at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.'));
 socket.once('error', (err) => {
   switch (err.code) {
     case 'ENOENT':
@@ -219,11 +242,77 @@ socket.once('error', (err) => {
     case 'ENOTSOCK':
       finish(false, 'Path ' + displayPath + ' is not a Unix socket.');
       break;
+    case 'ENOTSUP':
+      finish(false, 'connect ENOTSUP ' + displayPath);
+      break;
     default:
       finish(false, err.message || 'Unknown error connecting to socket');
   }
 });
 `;
+
+const BITCOIN_SOCKET_ENTRY_CHECK_SCRIPT = `
+const fs = require('fs');
+
+const socketPath = process.argv[1];
+const displayPath = process.argv[2] || socketPath;
+
+try {
+  const stat = fs.statSync(socketPath);
+  if (!stat.isSocket()) {
+    console.error('Path ' + displayPath + ' is not a Unix socket.');
+    process.exit(1);
+  }
+
+  process.exit(0);
+} catch (err) {
+  if (err && err.code === 'ENOENT') {
+    console.error('Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
+    process.exit(1);
+  }
+
+  // Docker Desktop can reject some metadata operations on macOS Unix sockets.
+  // If the directory entry is visible, let the IPC-response probe decide
+  // whether Bitcoin Core is actually running behind it.
+  if (err && (err.code === 'ENOTSUP' || err.code === 'EINVAL')) {
+    try {
+      const parent = require('path').dirname(socketPath);
+      const name = require('path').basename(socketPath);
+      process.exit(fs.readdirSync(parent).includes(name) ? 0 : 1);
+    } catch {
+      console.error('Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
+      process.exit(1);
+    }
+  }
+
+  console.error((err && err.message) || 'Unknown error checking socket path');
+  process.exit(1);
+}
+`;
+
+function getJdcContainerSocketPath(network: string): string {
+  return network === 'mainnet'
+    ? '/root/.bitcoin/node.sock'
+    : `/root/.bitcoin/${network}/node.sock`;
+}
+
+function getSocketEntryCheckPaths(socketPath: string): {
+  socketDir: string;
+  socketName: string;
+  containerDir: string;
+  containerSocketPath: string;
+} {
+  const socketDir = path.dirname(socketPath);
+  const socketName = path.basename(socketPath);
+  const containerDir = '/tmp/sv2-bitcoin-socket-dir';
+
+  return {
+    socketDir,
+    socketName,
+    containerDir,
+    containerSocketPath: `${containerDir}/${socketName}`,
+  };
+}
 
 /**
  * When sv2-ui runs in Docker, host paths such as ~/.bitcoin/node.sock are not
@@ -232,11 +321,26 @@ socket.once('error', (err) => {
  */
 export async function probeHostBitcoinSocketWithDocker(
   socketPath: string,
-  timeoutMs = 1000
+  timeoutMs = 1000,
+  options: BitcoinSocketValidationOptions = {}
 ): Promise<BitcoinSocketValidationResult> {
   refreshDockerConnection();
 
-  const helperSocketPath = '/tmp/sv2-bitcoin-node.sock';
+  const network = options.network ?? 'mainnet';
+  const containerSocketPath = getJdcContainerSocketPath(network);
+  const socketEntryCheck = await runBitcoinSocketEntryCheckContainer(socketPath);
+
+  if (!socketEntryCheck.valid) {
+    return socketEntryCheck;
+  }
+
+  return runBitcoinSocketValidatorContainer(socketPath, containerSocketPath, timeoutMs);
+}
+
+async function runBitcoinSocketEntryCheckContainer(
+  socketPath: string
+): Promise<BitcoinSocketValidationResult> {
+  const { socketDir, containerDir, containerSocketPath } = getSocketEntryCheckPaths(socketPath);
   let container: Docker.Container | null = null;
 
   try {
@@ -244,19 +348,77 @@ export async function probeHostBitcoinSocketWithDocker(
     container = await docker.createContainer({
       Image: image,
       Entrypoint: ['node'],
-      Cmd: ['-e', BITCOIN_SOCKET_VALIDATOR_SCRIPT, helperSocketPath, String(timeoutMs), socketPath],
+      Cmd: ['-e', BITCOIN_SOCKET_ENTRY_CHECK_SCRIPT, containerSocketPath, socketPath],
       AttachStdout: true,
       AttachStderr: true,
       HostConfig: {
-        NetworkMode: 'none',
         Mounts: [
           {
-            Type: 'bind',
-            Source: socketPath,
-            Target: helperSocketPath,
+            Type: 'bind' as const,
+            Source: socketDir,
+            Target: containerDir,
             ReadOnly: true,
           },
         ],
+        NetworkMode: 'none',
+        RestartPolicy: { Name: 'no' },
+      },
+    });
+
+    await container.start();
+    const result = await container.wait();
+
+    if (result.StatusCode === 0) {
+      return { valid: true };
+    }
+
+    const rawLogs = await container.logs({ stdout: true, stderr: true });
+    const message = demuxDockerLogBuffer(Buffer.isBuffer(rawLogs) ? rawLogs : Buffer.from(rawLogs))
+      .map((chunk) => chunk.payload.trim())
+      .filter(Boolean)
+      .join('\n');
+
+    return {
+      valid: false,
+      error: message || `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      valid: false,
+      error: message.includes('bind source path does not exist')
+        ? `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`
+        : message,
+    };
+  } finally {
+    if (container) {
+      try {
+        await container.remove({ force: true });
+      } catch {
+        // Best effort cleanup for short-lived validation containers.
+      }
+    }
+  }
+}
+
+async function runBitcoinSocketValidatorContainer(
+  socketPath: string,
+  containerSocketPath: string,
+  timeoutMs: number
+): Promise<BitcoinSocketValidationResult> {
+  let container: Docker.Container | null = null;
+
+  try {
+    const image = await getCurrentContainerImage();
+    container = await docker.createContainer({
+      Image: image,
+      Entrypoint: ['node'],
+      Cmd: ['-e', BITCOIN_SOCKET_VALIDATOR_SCRIPT, containerSocketPath, String(timeoutMs), socketPath],
+      AttachStdout: true,
+      AttachStderr: true,
+      HostConfig: {
+        Binds: [`${socketPath}:${containerSocketPath}:ro`],
+        NetworkMode: 'none',
         RestartPolicy: { Name: 'no' },
       },
     });
@@ -567,12 +729,9 @@ async function startJdc(
 ): Promise<void> {
   await removeContainer(JDC_CONTAINER);
 
-  // JDC resolves the socket path from its `network` setting: /root/.bitcoin/node.sock
-  // for mainnet, /root/.bitcoin/<network>/node.sock otherwise. Bind mount must match
-  // the path JDC actually looks at, not a hardcoded mainnet path.
-  const containerSocketPath = network === 'mainnet'
-    ? '/root/.bitcoin/node.sock'
-    : `/root/.bitcoin/${network}/node.sock`;
+  // JDC resolves the socket path from its `network` setting, so the bind mount
+  // must target the path JDC actually opens.
+  const containerSocketPath = getJdcContainerSocketPath(network);
 
   const binds = isRunningInDocker
     ? [

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,7 +22,9 @@ import {
   ensureDockerAvailable,
   getDockerConnectionInfo,
   expandHomePath,
-  readContainerLogs
+  readContainerLogs,
+  isRunningInsideDocker,
+  probeHostBitcoinSocketWithDocker
 } from './docker.js';
 import { getLogDiagnostics, getLogStreams, readCollatedLogLines } from './logs/diagnostics.js';
 
@@ -193,10 +195,25 @@ app.post('/api/validate/bitcoin-socket', async (req, res) => {
     return res.status(400).json({ valid: false, error: 'socket_path is required' });
   }
 
-  const resolved = expandHomePath(socket_path);
-  const result = await probeUnixSocket(resolved);
+  const result = await validateBitcoinSocket(socket_path);
   return res.json(result);
 });
+
+async function validateBitcoinSocket(socketPath: string): Promise<{ valid: true } | { valid: false; error: string }> {
+  const resolved = expandHomePath(socketPath);
+  return isRunningInsideDocker()
+    ? await probeHostBitcoinSocketWithDocker(resolved)
+    : await probeUnixSocket(resolved);
+}
+
+async function getBitcoinSocketStartupError(data: SetupData): Promise<string | null> {
+  if (data.mode !== 'jd' || !data.bitcoin) {
+    return null;
+  }
+
+  const result = await validateBitcoinSocket(data.bitcoin.socket_path);
+  return result.valid ? null : result.error;
+}
 
 /**
  * PUT /api/config - Update configuration and restart with new values
@@ -238,6 +255,11 @@ app.put('/api/config', async (req, res) => {
     }
 
     await ensureDockerAvailable();
+
+    const bitcoinSocketError = await getBitcoinSocketStartupError(newData);
+    if (bitcoinSocketError) {
+      return res.status(400).json({ success: false, error: bitcoinSocketError });
+    }
 
     await fs.mkdir(CONFIG_DIR, { recursive: true });
 
@@ -368,6 +390,11 @@ app.post('/api/setup', async (req, res) => {
 
     await ensureDockerAvailable();
 
+    const bitcoinSocketError = await getBitcoinSocketStartupError(data);
+    if (bitcoinSocketError) {
+      return res.status(400).json({ success: false, error: bitcoinSocketError });
+    }
+
     // Generate config files
     await fs.mkdir(CONFIG_DIR, { recursive: true });
 
@@ -455,6 +482,13 @@ app.post('/api/restart', async (_req, res) => {
     const bitcoinCoreVersionError = getBitcoinCoreVersionError(state.data);
     if (bitcoinCoreVersionError) {
       return res.status(400).json({ success: false, error: bitcoinCoreVersionError });
+    }
+
+    await ensureDockerAvailable();
+
+    const bitcoinSocketError = await getBitcoinSocketStartupError(state.data);
+    if (bitcoinSocketError) {
+      return res.status(400).json({ success: false, error: bitcoinSocketError });
     }
 
     await stopStack();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -190,19 +190,24 @@ function probeUnixSocket(socketPath: string, timeoutMs = 1000): Promise<{ valid:
  * POST /api/validate/bitcoin-socket - Check if a Bitcoin Core IPC socket is listening
  */
 app.post('/api/validate/bitcoin-socket', async (req, res) => {
-  const { socket_path } = req.body;
+  const { socket_path, network } = req.body;
   if (!socket_path || typeof socket_path !== 'string') {
     return res.status(400).json({ valid: false, error: 'socket_path is required' });
   }
 
-  const result = await validateBitcoinSocket(socket_path);
+  const result = await validateBitcoinSocket(socket_path, {
+    network: network === 'mainnet' || network === 'testnet4' ? network : undefined,
+  });
   return res.json(result);
 });
 
-async function validateBitcoinSocket(socketPath: string): Promise<{ valid: true } | { valid: false; error: string }> {
+async function validateBitcoinSocket(
+  socketPath: string,
+  options: { network?: 'mainnet' | 'testnet4' } = {}
+): Promise<{ valid: true } | { valid: false; error: string }> {
   const resolved = expandHomePath(socketPath);
   return isRunningInsideDocker()
-    ? await probeHostBitcoinSocketWithDocker(resolved)
+    ? await probeHostBitcoinSocketWithDocker(resolved, 1000, options)
     : await probeUnixSocket(resolved);
 }
 
@@ -211,7 +216,9 @@ async function getBitcoinSocketStartupError(data: SetupData): Promise<string | n
     return null;
   }
 
-  const result = await validateBitcoinSocket(data.bitcoin.socket_path);
+  const result = await validateBitcoinSocket(data.bitcoin.socket_path, {
+    network: data.bitcoin.network,
+  });
   return result.valid ? null : result.error;
 }
 

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -15,6 +15,7 @@ import {
   isValidPoolAuthorityPubkey,
   stripWrappingQuotes,
 } from '@/lib/utils';
+import { isBitcoinSocketError } from '@/lib/bitcoinSocketErrors';
 import type { SetupData } from '@/components/setup/types';
 import {
   Loader2,
@@ -50,6 +51,8 @@ function clearPersistedDashboardState() {
     window.localStorage.removeItem(key);
   });
 }
+
+const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
 
 type EditingField = null | 'pool' | 'mode' | 'identity' | 'signature' | 'advanced';
 
@@ -167,6 +170,11 @@ export function ConfigurationTab() {
         console.error('Reset failed:', error);
       }
     }
+  };
+
+  const handleOpenBitcoinSetup = () => {
+    window.sessionStorage.setItem(SETUP_TARGET_STEP_STORAGE_KEY, 'bitcoin');
+    navigate('/setup');
   };
 
   const startEditPool = () => {
@@ -402,11 +410,24 @@ export function ConfigurationTab() {
       {(stopError || restartError || setupError) && (
         <Card className="border-red-500/30 bg-red-500/5">
           <CardContent className="pt-6">
-            <div className="flex gap-3">
-              <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0" />
-              <p className="text-sm text-red-500">
-                {stopError?.message || restartError?.message || setupError?.message || 'Operation failed'}
-              </p>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex gap-3">
+                <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0" />
+                <p className="text-sm text-red-500">
+                  {stopError?.message || restartError?.message || setupError?.message || 'Operation failed'}
+                </p>
+              </div>
+              {isBitcoinSocketError(stopError || restartError || setupError) && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="destructive"
+                  onClick={handleOpenBitcoinSetup}
+                  className="sm:ml-4"
+                >
+                  Open Bitcoin Setup
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/components/setup/SetupWizard.tsx
+++ b/src/components/setup/SetupWizard.tsx
@@ -285,7 +285,13 @@ export function SetupWizard() {
             )}
             {currentStep === 'hashrate'        && <HashrateStep {...stepProps} />}
             {currentStep === 'identity'        && <MiningIdentityStep {...stepProps} />}
-            {currentStep === 'review'          && <ReviewStart {...stepProps} onComplete={handleComplete} />}
+            {currentStep === 'review'          && (
+              <ReviewStart
+                {...stepProps}
+                onComplete={handleComplete}
+                onGoToStep={setCurrentStep}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -51,7 +51,7 @@ export function BitcoinSetup({ data, updateData, onNext, notice, onDismissNotice
     error: socketError,
     isRetryable,
     retry: retrySocketValidation,
-  } = useBitcoinSocketValidation(socketPath);
+  } = useBitcoinSocketValidation(socketPath, network, coreVersion);
 
   const resetPath = () => { setManualSocketPath(''); setIsEditingPath(false); };
 

--- a/src/components/setup/steps/BitcoinSetup.tsx
+++ b/src/components/setup/steps/BitcoinSetup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { StepProps, BitcoinConfig, BitcoinCoreVersion, OperatingSystem } from '../types';
-import { Bitcoin, Apple, Terminal, Pencil, Check, Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Bitcoin, Apple, Terminal, Pencil, Check, Loader2, AlertCircle, CheckCircle2, RotateCw } from 'lucide-react';
 import { useBitcoinSocketValidation } from '@/hooks/useBitcoinSocketValidation';
 
 function getDefaultDataDir(os: OperatingSystem): string {
@@ -44,7 +44,14 @@ export function BitcoinSetup({ data, updateData, onNext, notice, onDismissNotice
     });
   }, [coreVersion, os, network, customDataDir, socketPath, updateData]);
 
-  const { isChecking, isValid, error: socketError } = useBitcoinSocketValidation(socketPath);
+  const {
+    isChecking,
+    isRefreshing,
+    isValid,
+    error: socketError,
+    isRetryable,
+    retry: retrySocketValidation,
+  } = useBitcoinSocketValidation(socketPath);
 
   const resetPath = () => { setManualSocketPath(''); setIsEditingPath(false); };
 
@@ -241,7 +248,25 @@ export function BitcoinSetup({ data, updateData, onNext, notice, onDismissNotice
             aria-live="assertive"
           >
             <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
-            <span>{socketError}</span>
+            <div className="flex-1 min-w-0 space-y-3">
+              <span className="block">{socketError}</span>
+              <button
+                type="button"
+                onClick={() => retrySocketValidation()}
+                disabled={isRefreshing}
+                className="inline-flex h-8 items-center gap-2 rounded-md border border-destructive/30 bg-background px-3 text-xs font-medium text-destructive transition-colors hover:bg-destructive/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isRefreshing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                ) : (
+                  <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {isRefreshing ? 'Checking...' : 'Retry'}
+              </button>
+              {isRetryable && (
+                <p className="text-xs text-destructive/80">Rechecking automatically while Bitcoin Core starts.</p>
+              )}
+            </div>
           </div>
         )}
       </div>
@@ -250,7 +275,7 @@ export function BitcoinSetup({ data, updateData, onNext, notice, onDismissNotice
         <button
           type="button"
           onClick={onNext}
-          disabled={!coreVersion || (!isChecking && !!socketError)}
+          disabled={!coreVersion || isChecking || !!socketError}
           className="h-11 px-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Continue

--- a/src/components/setup/steps/ReviewStart.tsx
+++ b/src/components/setup/steps/ReviewStart.tsx
@@ -1,16 +1,18 @@
 import React, { useState, useEffect } from "react";
-import { StepProps } from "../types";
+import { SetupStep, StepProps } from "../types";
 import { Loader2, AlertCircle } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { MinerConnectionInfo } from "../MinerConnectionInfo";
 import { shouldAggregateTranslatorChannels } from "../poolRules";
+import { isBitcoinSocketError } from "@/lib/bitcoinSocketErrors";
 import { formatHashrate } from "@/lib/utils";
 
 interface ReviewStartProps extends StepProps {
   onComplete: () => void;
+  onGoToStep: (step: SetupStep) => void;
 }
 
-export function ReviewStart({ data, onComplete }: ReviewStartProps) {
+export function ReviewStart({ data, onComplete, onGoToStep }: ReviewStartProps) {
   const queryClient = useQueryClient();
   const [isStarting, setIsStarting] = useState(false);
   const [started, setStarted] = useState(false);
@@ -31,6 +33,7 @@ export function ReviewStart({ data, onComplete }: ReviewStartProps) {
       : "Pool Templates";
   const isAggregatedTproxy =
     !isSoloMode && shouldAggregateTranslatorChannels(data.pool);
+  const showBitcoinSetupButton = isJdMode && isBitcoinSocketError(error);
 
   let sectionCount = 0;
   const nextSection = () => (++sectionCount).toString();
@@ -164,6 +167,18 @@ export function ReviewStart({ data, onComplete }: ReviewStartProps) {
               Error
             </div>
             <div className="text-sm text-muted-foreground">{error}</div>
+            {showBitcoinSetupButton && (
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  onGoToStep("bitcoin");
+                }}
+                className="mt-3 inline-flex h-9 items-center justify-center rounded-full bg-destructive px-4 text-sm font-medium text-destructive-foreground transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30"
+              >
+                Open Bitcoin Setup
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/src/components/setup/steps/ReviewStart.tsx
+++ b/src/components/setup/steps/ReviewStart.tsx
@@ -12,6 +12,23 @@ interface ReviewStartProps extends StepProps {
   onGoToStep: (step: SetupStep) => void;
 }
 
+async function confirmStackStarted(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5_000);
+
+  try {
+    const response = await fetch("/api/status", { signal: controller.signal });
+    if (!response.ok) return false;
+
+    const status = await response.json();
+    return status.configured === true && status.running === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 export function ReviewStart({ data, onComplete, onGoToStep }: ReviewStartProps) {
   const queryClient = useQueryClient();
   const [isStarting, setIsStarting] = useState(false);
@@ -65,6 +82,18 @@ export function ReviewStart({ data, onComplete, onGoToStep }: ReviewStartProps) 
     } catch (err) {
       let message = "Failed to start services";
       if (err instanceof Error) {
+        const mayHaveStarted =
+          err.name === "AbortError" ||
+          err.message.includes("fetch") ||
+          err.message.includes("Network");
+
+        if (mayHaveStarted && await confirmStackStarted()) {
+          await queryClient.invalidateQueries({ queryKey: ["setup-status"] });
+          setStarted(true);
+          setIsStarting(false);
+          return;
+        }
+
         if (err.name === "AbortError") {
           message =
             "Request timed out. The containers may still be starting — check the terminal.";

--- a/src/hooks/useBitcoinSocketValidation.ts
+++ b/src/hooks/useBitcoinSocketValidation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { isRetryableBitcoinSocketError } from '@/lib/bitcoinSocketErrors';
 
 interface SocketValidationResult {
   valid: boolean;
@@ -41,21 +42,30 @@ export function useBitcoinSocketValidation(socketPath: string, debounceMs = 800)
     return () => clearTimeout(t);
   }, [socketPath, debounceMs]);
 
-  const { data, isFetching } = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: ['bitcoin-socket-validation', debouncedPath],
     queryFn: () => validateSocket(debouncedPath),
     enabled: !!debouncedPath,
-    staleTime: 10_000,
+    staleTime: 0,
     retry: false,
+    refetchOnMount: 'always',
+    refetchInterval: (query) => {
+      const result = query.state.data as SocketValidationResult | null | undefined;
+      return result && !result.valid && isRetryableBitcoinSocketError(result.error) ? 5_000 : false;
+    },
     refetchOnWindowFocus: false,
   });
 
   const isPathStale = debouncedPath !== socketPath;
+  const isRetryable = data && !data.valid ? isRetryableBitcoinSocketError(data.error) : false;
 
   return {
     isChecking: isFetching || isPathStale,
+    isRefreshing: isFetching && !!data,
     isValid: data?.valid === true,
     error: data && !data.valid ? data.error : undefined,
+    isRetryable,
+    retry: () => refetch(),
     skipped: data === null,
   };
 }

--- a/src/hooks/useBitcoinSocketValidation.ts
+++ b/src/hooks/useBitcoinSocketValidation.ts
@@ -7,16 +7,28 @@ interface SocketValidationResult {
   error?: string;
 }
 
+type BitcoinSocketValidationParams = {
+  socketPath: string;
+  network: 'mainnet' | 'testnet4';
+  coreVersion: '30.2' | '31.0' | null;
+};
+
 // Returns null when the backend is not reachable (standalone mode — skip validation).
-async function validateSocket(socketPath: string): Promise<SocketValidationResult | null> {
+async function validateSocket({
+  socketPath,
+  network,
+}: BitcoinSocketValidationParams): Promise<SocketValidationResult | null> {
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
+    const timeoutId = setTimeout(() => controller.abort(), 120_000);
 
     const response = await fetch('/api/validate/bitcoin-socket', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ socket_path: socketPath }),
+      body: JSON.stringify({
+        socket_path: socketPath,
+        network,
+      }),
       signal: controller.signal,
     });
 
@@ -34,7 +46,12 @@ async function validateSocket(socketPath: string): Promise<SocketValidationResul
  * input so we don't probe on every keystroke, and silently no-ops when the
  * backend isn't reachable (standalone mode).
  */
-export function useBitcoinSocketValidation(socketPath: string, debounceMs = 800) {
+export function useBitcoinSocketValidation(
+  socketPath: string,
+  network: 'mainnet' | 'testnet4',
+  coreVersion: '30.2' | '31.0' | null,
+  debounceMs = 800
+) {
   const [debouncedPath, setDebouncedPath] = useState(socketPath);
 
   useEffect(() => {
@@ -43,9 +60,9 @@ export function useBitcoinSocketValidation(socketPath: string, debounceMs = 800)
   }, [socketPath, debounceMs]);
 
   const { data, isFetching, refetch } = useQuery({
-    queryKey: ['bitcoin-socket-validation', debouncedPath],
-    queryFn: () => validateSocket(debouncedPath),
-    enabled: !!debouncedPath,
+    queryKey: ['bitcoin-socket-validation', debouncedPath, network, coreVersion],
+    queryFn: () => validateSocket({ socketPath: debouncedPath, network, coreVersion }),
+    enabled: !!debouncedPath && !!coreVersion,
     staleTime: 0,
     retry: false,
     refetchOnMount: 'always',

--- a/src/hooks/useControlApi.ts
+++ b/src/hooks/useControlApi.ts
@@ -6,6 +6,14 @@ interface ControlResponse {
   error?: string;
 }
 
+async function parseControlResponse(response: Response): Promise<ControlResponse> {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || data.success === false) {
+    throw new Error(data.error || data.message || `Request failed (${response.status})`);
+  }
+  return data;
+}
+
 /**
  * Stop all containers
  */
@@ -13,7 +21,7 @@ async function stopServices(): Promise<ControlResponse> {
   const response = await fetch('/api/stop', {
     method: 'POST',
   });
-  return response.json();
+  return parseControlResponse(response);
 }
 
 /**
@@ -23,7 +31,7 @@ async function restartServices(): Promise<ControlResponse> {
   const response = await fetch('/api/restart', {
     method: 'POST',
   });
-  return response.json();
+  return parseControlResponse(response);
 }
 
 /**
@@ -35,7 +43,7 @@ async function setupServices(config: SetupData): Promise<ControlResponse> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(config),
   });
-  return response.json();
+  return parseControlResponse(response);
 }
 
 /**
@@ -47,7 +55,7 @@ async function updateConfigService(updates: Partial<SetupData>): Promise<Control
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(updates),
   });
-  return response.json();
+  return parseControlResponse(response);
 }
 
 /**

--- a/src/lib/bitcoinSocketErrors.ts
+++ b/src/lib/bitcoinSocketErrors.ts
@@ -1,0 +1,22 @@
+const BITCOIN_SOCKET_ERROR_PATTERNS = [
+  'Socket not found at',
+  'Socket file exists at',
+  'Socket did not respond',
+  'Permission denied for',
+  'is not a Unix socket',
+];
+
+function getErrorMessage(error?: string | Error | null): string {
+  if (!error) return '';
+  return typeof error === 'string' ? error : error.message;
+}
+
+export function isBitcoinSocketError(error?: string | Error | null): boolean {
+  const message = getErrorMessage(error);
+  return BITCOIN_SOCKET_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+export function isRetryableBitcoinSocketError(error?: string | Error | null): boolean {
+  const message = getErrorMessage(error);
+  return message.includes('nothing is listening') || message.includes('did not respond');
+}

--- a/src/lib/bitcoinSocketErrors.ts
+++ b/src/lib/bitcoinSocketErrors.ts
@@ -4,6 +4,7 @@ const BITCOIN_SOCKET_ERROR_PATTERNS = [
   'Socket did not respond',
   'Permission denied for',
   'is not a Unix socket',
+  'Bitcoin Core version does not match',
 ];
 
 function getErrorMessage(error?: string | Error | null): string {

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -40,6 +40,7 @@ const RANGE_DESCRIPTIONS: Record<TimeRange, string> = {
   '1h': 'Last hour · sampled every 5 seconds',
 };
 const BITCOIN_CORE_VERSION_MISMATCH_CODE = 'jdc-bitcoin-core-unsupported-mining-interface';
+const BITCOIN_CORE_DISCONNECTED_CODE = 'jdc-bitcoin-core-disconnected';
 const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
 
 function normalizeUserIdentity(userIdentity: string) {
@@ -500,7 +501,9 @@ export function UnifiedDashboard() {
 
       {/* log-derived Diagnostic Banners */}
       {diagnostics.map((diagnostic) => {
-        const showReconfigureButton = diagnostic.code === BITCOIN_CORE_VERSION_MISMATCH_CODE;
+        const showBitcoinSetupButton =
+          diagnostic.code === BITCOIN_CORE_VERSION_MISMATCH_CODE ||
+          diagnostic.code === BITCOIN_CORE_DISCONNECTED_CODE;
 
         return (
           <div
@@ -521,13 +524,13 @@ export function UnifiedDashboard() {
                 )}
               </div>
             </div>
-            {showReconfigureButton && (
+            {showBitcoinSetupButton && (
               <Link
                 href="/setup"
                 onClick={() => window.sessionStorage.setItem(SETUP_TARGET_STEP_STORAGE_KEY, 'bitcoin')}
                 className="inline-flex h-9 shrink-0 items-center justify-center rounded-full bg-red-500 px-4 font-medium text-white transition-colors hover:bg-red-600 sm:ml-4"
               >
-                Reconfigure
+                Open Bitcoin Setup
               </Link>
             )}
           </div>


### PR DESCRIPTION
In https://github.com/stratum-mining/sv2-ui/pull/90 we introduced a validation process during Bitcoin Core setup.

The problem is that while it's working when running `sv2-ui` with `npm run dev` (because it has access to the host), it doesn't work when launching `sv2-ui` inside docker (what our users are doing as suggested on our website).

And the reason is that the container in that case doesn't have access to the host, so it's not able to find the `node.sock` file, even though the node is running and the socket file exists in reality:

<img width="1600" height="1049" alt="image" src="https://github.com/user-attachments/assets/f9d69654-75a4-4e26-86ff-1a155404b7b0" />

---

This PR addresses that by validating the socket path from the Docker runtime instead of from the `sv2-ui` container filesystem.

Implementation notes:
- The validator starts a short-lived helper container and bind-mounts the Bitcoin data directory containing `node.sock`.
- It retries with Docker `Binds`, matching how the JDC container mounts the same socket at runtime.
- On Linux, validation succeeds only when the helper can connect to the socket.
- On macOS Docker Desktop, helper `connect()`/`stat()` calls can return `ENOTSUP` for host-mounted Unix sockets. In that case, the validator falls back to a short-lived probe using the selected JDC image, a temporary JDC config, and the same socket bind path JDC uses at runtime.
- The JDC probe waits for JDC's own Bitcoin Core IPC bootstrap success log, so a stale `node.sock` file left behind after Bitcoin Core stops is rejected instead of treated as valid.

In case the socket is not active, the setup UI shows an error and automatically retries retryable failures every 5s.

https://github.com/user-attachments/assets/9cc0b628-1099-472d-8baa-fb3da069493b