### PR TITLE
surface contextual Docker error when daemon is unreachable

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -103,7 +103,14 @@ app.get('/api/status', async (_req, res) => {
   try {
     const state = await loadState();
     const containers = await getStackStatus(state.mode);
-    
+
+    // Cap the Docker reachability probe so a slow daemon ping does not stall
+    // the /api/status response. The frontend has its own 1.5s abort on top.
+    const dockerReachable = await Promise.race([
+      isDockerAvailable(),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 500)),
+    ]);
+
     const running = state.mode === 'jd'
       ? (containers.translator?.status === 'healthy' || containers.translator?.status === 'starting') &&
         (containers.jdc?.status === 'healthy' || containers.jdc?.status === 'starting')
@@ -118,6 +125,7 @@ app.get('/api/status', async (_req, res) => {
         ? 'Sovereign Solo Mining'
         : (state.data?.pool?.name ?? null),
       containers,
+      docker: { reachable: dockerReachable },
     };
 
     res.json(response);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -66,6 +66,9 @@ export interface StatusResponse {
     translator: ContainerStatus | null;
     jdc: ContainerStatus | null;
   };
+  docker: {
+    reachable: boolean;
+  };
 }
 
 export interface SetupResponse {

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -10,6 +10,9 @@ export interface SetupStatus {
     translator: { id: string; name: string; status: string } | null;
     jdc: { id: string; name: string; status: string } | null;
   };
+  docker?: {
+    reachable: boolean;
+  };
 }
 
 /**
@@ -73,6 +76,8 @@ export function useSetupStatus() {
     mode: status?.mode ?? null,
     poolName: status?.poolName ?? null,
     containers: status?.containers ?? { translator: null, jdc: null },
+    // null when standalone or before first status response; true/false from the backend.
+    dockerReachable: status?.docker?.reachable ?? null,
     // User needs setup if: orchestrated mode AND not yet configured
     needsSetup: status !== null && status !== undefined && !status.configured,
     refetch: query.refetch,

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -122,19 +122,28 @@ export function UnifiedDashboard() {
   const diagnostics = logDiagnostics?.diagnostics ?? [];
 
   const [isStarting, setIsStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
 
   const handleStartMining = async () => {
     setIsStarting(true);
+    setStartError(null);
     try {
       const response = await fetch('/api/restart', { method: 'POST' });
-      if (response.ok) {
-        // Give containers time to start, then refresh health checks
-        setTimeout(() => {
-          window.location.reload();
-        }, 3000);
+      const errorData = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(
+          errorData.error || errorData.message || `Failed (${response.status})`,
+        );
       }
+      // Give containers time to start, then refresh health checks
+      setTimeout(() => {
+        window.location.reload();
+      }, 3000);
     } catch (error) {
       console.error('Failed to start mining:', error);
+      setStartError(
+        error instanceof Error ? error.message : 'Failed to start mining services',
+      );
       setIsStarting(false);
     }
   };
@@ -467,26 +476,52 @@ export function UnifiedDashboard() {
 
       {/* Start Mining Banner (configured but stopped) */}
       {configuredButStopped && showError && (
-        <div className="flex items-center justify-between gap-3 rounded-xl border border-primary/40 bg-primary/10 px-5 py-4 text-sm">
-          <div className="flex items-center gap-3">
-            <Play className="h-4 w-4 shrink-0 text-primary" />
-            <span>Mining services are stopped.</span>
+        startError ? (
+          <div className="flex flex-col gap-3 rounded-xl border border-red-500/40 bg-red-500/10 px-5 py-4 text-sm text-red-500 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">Could not start mining services</span>
+                <span>{startError}</span>
+              </div>
+            </div>
+            <button
+              onClick={handleStartMining}
+              disabled={isStarting}
+              className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-full bg-red-500 px-4 font-medium text-white transition-colors hover:bg-red-600 disabled:opacity-50 sm:ml-4"
+            >
+              {isStarting ? (
+                <>
+                  <div className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                'Try again'
+              )}
+            </button>
           </div>
-          <button
-            onClick={handleStartMining}
-            disabled={isStarting}
-            className="h-9 px-4 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors font-medium flex items-center gap-2"
-          >
-            {isStarting ? (
-              <>
-                <div className="h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
-                Starting...
-              </>
-            ) : (
-              'Start Mining'
-            )}
-          </button>
-        </div>
+        ) : (
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-primary/40 bg-primary/10 px-5 py-4 text-sm">
+            <div className="flex items-center gap-3">
+              <Play className="h-4 w-4 shrink-0 text-primary" />
+              <span>Mining services are stopped.</span>
+            </div>
+            <button
+              onClick={handleStartMining}
+              disabled={isStarting}
+              className="h-9 px-4 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors font-medium flex items-center gap-2"
+            >
+              {isStarting ? (
+                <>
+                  <div className="h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                'Start Mining'
+              )}
+            </button>
+          </div>
+        )
       )}
 
       {/* Connection Error Banner (not configured or unknown error) */}

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -81,6 +81,7 @@ export function UnifiedDashboard() {
     miningMode,
     mode: templateMode,
     poolName: configPoolName,
+    dockerReachable,
   } = useSetupStatus();
 
   // Header connection status (shared with Settings via hook)
@@ -476,7 +477,32 @@ export function UnifiedDashboard() {
 
       {/* Start Mining Banner (configured but stopped) */}
       {configuredButStopped && showError && (
-        startError ? (
+        dockerReachable === false ? (
+          <div className="flex flex-col gap-3 rounded-xl border border-red-500/40 bg-red-500/10 px-5 py-4 text-sm text-red-500 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <div className="flex flex-col gap-1">
+                <span className="font-medium">Docker isn't running</span>
+                <span>We couldn't reach the Docker daemon, so mining services can't start.</span>
+                <span className="text-current/80">Start Docker Desktop or Docker Engine, then click Start Mining.</span>
+              </div>
+            </div>
+            <button
+              onClick={handleStartMining}
+              disabled={isStarting}
+              className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-full bg-red-500 px-4 font-medium text-white transition-colors hover:bg-red-600 disabled:opacity-50 sm:ml-4"
+            >
+              {isStarting ? (
+                <>
+                  <div className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                'Start Mining'
+              )}
+            </button>
+          </div>
+        ) : startError ? (
           <div className="flex flex-col gap-3 rounded-xl border border-red-500/40 bg-red-500/10 px-5 py-4 text-sm text-red-500 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
               <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />


### PR DESCRIPTION


## Body



before this, when docker quit while sv2-ui was running, the dashboard just said "Mining services are stopped." and the start mining button silently failed. now it tells you docker is the actual problem and shows the contextual error from the backend.

two changes:

- `/api/status` now returns `docker: { reachable: boolean }`. when false, the dashboard shows a red "Docker isn't running" banner. wrapped the ping in a 500ms `Promise.race` so a slow daemon can't stall the status response.
- `handleStartMining` was throwing away the response body when `/api/restart` 500'd. now it parses the body the same way `ReviewStart.tsx:73-77` already does in the wizard, and shows the contextual error string verbatim in a red "Could not start mining services" banner.

priority on the configured-but-stopped state: docker-down > start-error > existing "stopped" banner. the Start Mining button stays in all three so the user can retry once docker is back.



tested in WSL with native docker:

- typecheck, lint, build clean.
- `sudo systemctl stop docker docker.socket` → red banner appears within ~10s. clicked Start Mining with docker still down → 500 with the contextual error (visible in screenshots). `sudo systemctl start docker` → banner returns to the blue stopped state and Start Mining works again.
<img width="1120" height="474" alt="Screenshot 2026-05-09 155846" src="https://github.com/user-attachments/assets/cf1b74ee-4213-481d-8cc2-f69044cfcc70" />
<img width="2556" height="1317" alt="Screenshot 2026-05-09 155143" src="https://github.com/user-attachments/assets/70c2aedc-e490-452d-b462-09f7c8e7b3d7" />


**not in this PR: settings page has the same gap on its start/stop controls, happy to do that as a follow-up if you want. no UI tests for the banner branching because there's no jsdom/testing-library in the repo today.**

closes #144