### PR TITLE
refactor: unify Bitcoin socket validation through Docker containers

### DIFF
--- a/server/src/bitcoin-socket-exists.ts
+++ b/server/src/bitcoin-socket-exists.ts
@@ -1,0 +1,15 @@
+export const bitcoinSocketExistsScript = `const fs = require('fs');
+const { execSync } = require('child_process');
+
+const socketPath = process.argv[1];
+const dir = require('path').dirname(socketPath);
+
+try {
+  console.log('DEBUG: Checking path:', socketPath);
+  console.log('DEBUG: Directory contents:', execSync('ls -la ' + dir).toString());
+  console.log('DEBUG: exists:', fs.existsSync(socketPath));
+} catch(e) {
+  console.log('DEBUG ERROR:', e.message);
+}
+
+process.exit(fs.existsSync(socketPath) ? 0 : 1);`;

--- a/server/src/bitcoin-socket-validator.ts
+++ b/server/src/bitcoin-socket-validator.ts
@@ -1,0 +1,107 @@
+export const bitcoinSocketValidatorScript = `const net = require('net');
+const fs = require('fs');
+
+const socketPath = process.argv[1];
+const timeoutMs = Number(process.argv[2] || 1000);
+const displayPath = process.argv[3] || socketPath;
+
+const socket = net.createConnection({ path: socketPath });
+
+let settled = false;
+
+function finish(ok, message) {
+  if (settled) {
+    return;
+  }
+
+  settled = true;
+  socket.destroy();
+
+  if (!ok && message) {
+    console.error(message);
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+socket.setTimeout(timeoutMs + 500); // Add buffer to timeout
+
+socket.once('connect', () => {
+  socket.end();
+});
+
+socket.once('data', (chunk) => {
+  const response = chunk.toString('utf8');
+  if (/peer disconnected/i.test(response)) {
+    finish(true);
+    return;
+  }
+  finish(false, 'Socket responded but did not look like Bitcoin Core IPC.');
+});
+
+socket.once('timeout', () => {
+  finish(
+    false,
+    'Timed out connecting to socket at ' +
+    displayPath +
+    '. Make sure Bitcoin Core is running with IPC enabled.'
+  );
+});
+
+socket.once('error', (err) => {
+  switch (err.code) {
+    case 'ENOENT':
+      finish(
+        false,
+        'Socket not found at ' +
+        displayPath +
+        '. Make sure Bitcoin Core is running with IPC enabled.'
+      );
+      break;
+
+    case 'ECONNREFUSED':
+      finish(
+        false,
+        'Socket file exists at ' +
+        displayPath +
+        ' but nothing is listening. Bitcoin Core may have crashed or been stopped.'
+      );
+      break;
+
+    case 'EACCES':
+      finish(
+        false,
+        'Permission denied for ' +
+        displayPath +
+        '. Check that the sv2-ui process can access this socket.'
+      );
+      break;
+
+    case 'ENOTSOCK':
+      finish(
+        false,
+        'Path ' + displayPath + ' is not a Unix socket.'
+      );
+      break;
+
+    case 'ENOTSUP':
+      finish(
+        false,
+        'Unix sockets are not supported for ' + displayPath
+      );
+      break;
+
+    default:
+      finish(
+        false,
+        err.message || 'Unknown error connecting to socket'
+      );
+  }
+});
+
+// Fallback: ensure we always exit explicitly
+setTimeout(() => {
+  if (!settled) {
+    finish(false, 'Socket validation timed out. Make sure Bitcoin Core is running with IPC enabled.');
+  }
+}, timeoutMs + 2000);`;

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -3,12 +3,15 @@
  */
 
 import fs from 'fs';
+import path from 'path'
 import Docker from 'dockerode';
 import os from 'os';
-import path from 'path';
 import type { SetupData, ContainerStatus, HealthStatus } from './types.js';
 import type { ContainerLogLine, LogContainerRole, LogOutputStream } from './logs/types.js';
 import { getImageSelectionForSetup } from './compatibility.js';
+import { bitcoinSocketValidatorScript } from './bitcoin-socket-validator.js';
+import { bitcoinSocketExistsScript } from './bitcoin-socket-exists.js';
+
 
 /**
  * Expand ~ to home directory in a path.
@@ -168,127 +171,6 @@ export type BitcoinSocketValidationResult =
   | { valid: true }
   | { valid: false; error: string };
 
-type BitcoinSocketValidationOptions = {
-  network?: 'mainnet' | 'testnet4';
-};
-
-async function getCurrentContainerImage(): Promise<string> {
-  const configuredImage = process.env.SV2_UI_VALIDATOR_IMAGE?.trim();
-  if (configuredImage) {
-    return configuredImage;
-  }
-
-  try {
-    const self = await docker.getContainer(os.hostname()).inspect();
-    if (self.Config?.Image) {
-      return self.Config.Image;
-    }
-  } catch (error) {
-    console.warn('Could not inspect sv2-ui container image for socket validation:', error);
-  }
-
-  return 'stratumv2/sv2-ui:latest';
-}
-
-const BITCOIN_SOCKET_VALIDATOR_SCRIPT = `
-const net = require('net');
-
-const socketPath = process.argv[1];
-const timeoutMs = Number(process.argv[2] || 1000);
-const displayPath = process.argv[3] || socketPath;
-const socket = net.createConnection({ path: socketPath });
-let settled = false;
-
-function finish(ok, message) {
-  if (settled) return;
-  settled = true;
-  socket.destroy();
-  if (!ok && message) console.error(message);
-  process.exit(ok ? 0 : 1);
-}
-
-socket.setTimeout(timeoutMs);
-socket.once('connect', () => {
-  // Docker Desktop on macOS can report a successful connect for stale
-  // bind-mounted Unix sockets. Bitcoin Core's IPC server sends a
-  // libmultiprocess/Cap'n Proto "Peer disconnected" response when the client
-  // immediately closes the write side, which proves a real IPC process replied.
-  socket.end();
-});
-socket.once('data', (chunk) => {
-  const response = chunk.toString('utf8');
-  if (/peer disconnected/i.test(response)) {
-    finish(true);
-    return;
-  }
-
-  finish(false, 'Socket responded at ' + displayPath + ', but it did not look like Bitcoin Core IPC.');
-});
-socket.once('close', () => {
-  finish(false, 'Socket did not respond with Bitcoin Core IPC data at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
-});
-socket.once('timeout', () => finish(false, 'Socket did not respond with Bitcoin Core IPC data at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.'));
-socket.once('error', (err) => {
-  switch (err.code) {
-    case 'ENOENT':
-      finish(false, 'Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
-      break;
-    case 'ECONNREFUSED':
-      finish(false, 'Socket file exists at ' + displayPath + ' but nothing is listening. Bitcoin Core may have crashed or been stopped.');
-      break;
-    case 'EACCES':
-      finish(false, 'Permission denied for ' + displayPath + '. Check that the sv2-ui process can read this file.');
-      break;
-    case 'ENOTSOCK':
-      finish(false, 'Path ' + displayPath + ' is not a Unix socket.');
-      break;
-    case 'ENOTSUP':
-      finish(false, 'connect ENOTSUP ' + displayPath);
-      break;
-    default:
-      finish(false, err.message || 'Unknown error connecting to socket');
-  }
-});
-`;
-
-const BITCOIN_SOCKET_ENTRY_CHECK_SCRIPT = `
-const fs = require('fs');
-
-const socketPath = process.argv[1];
-const displayPath = process.argv[2] || socketPath;
-
-try {
-  const stat = fs.statSync(socketPath);
-  if (!stat.isSocket()) {
-    console.error('Path ' + displayPath + ' is not a Unix socket.');
-    process.exit(1);
-  }
-
-  process.exit(0);
-} catch (err) {
-  if (err && err.code === 'ENOENT') {
-    console.error('Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
-    process.exit(1);
-  }
-
-  // Docker Desktop can reject some metadata operations on macOS Unix sockets.
-  // If the directory entry is visible, let the IPC-response probe decide
-  // whether Bitcoin Core is actually running behind it.
-  if (err && (err.code === 'ENOTSUP' || err.code === 'EINVAL')) {
-    try {
-      const parent = require('path').dirname(socketPath);
-      const name = require('path').basename(socketPath);
-      process.exit(fs.readdirSync(parent).includes(name) ? 0 : 1);
-    } catch {
-      console.error('Socket not found at ' + displayPath + '. Make sure Bitcoin Core is running with IPC enabled.');
-      process.exit(1);
-    }
-  }
-
-  console.error((err && err.message) || 'Unknown error checking socket path');
-  process.exit(1);
-}
-`;
 
 function getJdcContainerSocketPath(network: string): string {
   return network === 'mainnet'
@@ -296,69 +178,62 @@ function getJdcContainerSocketPath(network: string): string {
     : `/root/.bitcoin/${network}/node.sock`;
 }
 
-function getSocketEntryCheckPaths(socketPath: string): {
-  socketDir: string;
-  socketName: string;
-  containerDir: string;
-  containerSocketPath: string;
-} {
-  const socketDir = path.dirname(socketPath);
-  const socketName = path.basename(socketPath);
-  const containerDir = '/tmp/sv2-bitcoin-socket-dir';
-
-  return {
-    socketDir,
-    socketName,
-    containerDir,
-    containerSocketPath: `${containerDir}/${socketName}`,
-  };
-}
-
 /**
  * When sv2-ui runs in Docker, host paths such as ~/.bitcoin/node.sock are not
  * visible inside the sv2-ui container. Validate the socket through Docker by
  * bind-mounting the host socket into a short-lived helper container.
+ *
+ * Two-step approach:
+ * 1. First: Check if socket file exists (mount parent directory)
+ * 2. Second: Full socket connection validation (mount socket directly)
  */
-export async function probeHostBitcoinSocketWithDocker(
+export async function probeBitcoinSocketWithDocker(
   socketPath: string,
-  timeoutMs = 1000,
-  options: BitcoinSocketValidationOptions = {}
 ): Promise<BitcoinSocketValidationResult> {
-  refreshDockerConnection();
-
-  const network = options.network ?? 'mainnet';
-  const containerSocketPath = getJdcContainerSocketPath(network);
-  const socketEntryCheck = await runBitcoinSocketEntryCheckContainer(socketPath);
-
-  if (!socketEntryCheck.valid) {
-    return socketEntryCheck;
-  }
-
-  return runBitcoinSocketValidatorContainer(socketPath, containerSocketPath, timeoutMs);
-}
-
-async function runBitcoinSocketEntryCheckContainer(
-  socketPath: string
-): Promise<BitcoinSocketValidationResult> {
-  const { socketDir, containerDir, containerSocketPath } = getSocketEntryCheckPaths(socketPath);
-  let container: Docker.Container | null = null;
+  const containerSocketPath = "/tmp/bitcoin/node.sock";
 
   try {
-    const image = await getCurrentContainerImage();
+    await pullImage("node:20-bookworm-slim");
+
+    // Step 1: Check if socket file exists
+    const existsResult = await checkSocketExists(socketPath, containerSocketPath);
+    if (!existsResult) {
+      return {
+        valid: false,
+        error: `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`,
+      };
+    }
+
+    // Step 2: Full socket validation
+    return await validateSocketWithDocker(socketPath, containerSocketPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      valid: false,
+      error: `Failed to validate socket: ${message}`,
+    };
+  }
+}
+
+async function checkSocketExists(
+  socketPath: string,
+  containerSocketPath: string,
+): Promise<boolean> {
+  let container: Docker.Container | null = null;
+  try {
     container = await docker.createContainer({
-      Image: image,
+      Image: 'node:20-bookworm-slim',
       Entrypoint: ['node'],
-      Cmd: ['-e', BITCOIN_SOCKET_ENTRY_CHECK_SCRIPT, containerSocketPath, socketPath],
+      Cmd: ['-e', bitcoinSocketExistsScript, containerSocketPath],
       AttachStdout: true,
       AttachStderr: true,
       HostConfig: {
         Mounts: [
           {
-            Type: 'bind' as const,
-            Source: socketDir,
-            Target: containerDir,
-            ReadOnly: true,
-          },
+            Type: "bind",
+            Source: path.dirname(socketPath),
+            Target: path.dirname(containerSocketPath)
+          }
         ],
         NetworkMode: 'none',
         RestartPolicy: { Name: 'no' },
@@ -368,52 +243,31 @@ async function runBitcoinSocketEntryCheckContainer(
     await container.start();
     const result = await container.wait();
 
-    if (result.StatusCode === 0) {
-      return { valid: true };
-    }
-
-    const rawLogs = await container.logs({ stdout: true, stderr: true });
-    const message = demuxDockerLogBuffer(Buffer.isBuffer(rawLogs) ? rawLogs : Buffer.from(rawLogs))
-      .map((chunk) => chunk.payload.trim())
-      .filter(Boolean)
-      .join('\n');
-
-    return {
-      valid: false,
-      error: message || `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`,
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      valid: false,
-      error: message.includes('bind source path does not exist')
-        ? `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`
-        : message,
-    };
+    return result.StatusCode === 0;
+  } catch {
+    return false;
   } finally {
     if (container) {
       try {
         await container.remove({ force: true });
       } catch {
-        // Best effort cleanup for short-lived validation containers.
+        // if the operation above failed we have bigger problems
       }
     }
   }
 }
 
-async function runBitcoinSocketValidatorContainer(
+async function validateSocketWithDocker(
   socketPath: string,
   containerSocketPath: string,
-  timeoutMs: number
 ): Promise<BitcoinSocketValidationResult> {
   let container: Docker.Container | null = null;
 
   try {
-    const image = await getCurrentContainerImage();
     container = await docker.createContainer({
-      Image: image,
+      Image: 'node:20-bookworm-slim',
       Entrypoint: ['node'],
-      Cmd: ['-e', BITCOIN_SOCKET_VALIDATOR_SCRIPT, containerSocketPath, String(timeoutMs), socketPath],
+      Cmd: ['-e', bitcoinSocketValidatorScript, containerSocketPath, "1000", socketPath],
       AttachStdout: true,
       AttachStderr: true,
       HostConfig: {
@@ -440,20 +294,17 @@ async function runBitcoinSocketValidatorContainer(
       valid: false,
       error: message || `Socket validation failed for ${socketPath}`,
     };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  } catch {
     return {
       valid: false,
-      error: message.includes('bind source path does not exist')
-        ? `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`
-        : message,
+      error: `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.`
     };
   } finally {
     if (container) {
       try {
         await container.remove({ force: true });
       } catch {
-        // Best effort cleanup for short-lived validation containers.
+        // if the operation above fais we have bigger problems
       }
     }
   }
@@ -613,9 +464,16 @@ async function connectSv2UiToNetwork(): Promise<void> {
 
 /**
  * Pull the latest version of an image from Docker Hub.
- * Always pulls to ensure we have the most recent version.
+ * Only pulls if the image doesn't exist locally.
  */
 async function pullImage(imageName: string): Promise<void> {
+  try {
+    await docker.getImage(imageName).inspect();
+    return;
+  } catch {
+    // Image not found locally, proceed to pull
+  }
+
   console.log(`Pulling latest ${imageName}...`);
   await new Promise<void>((resolve, reject) => {
     docker.pull(imageName, (err: Error | null, stream: NodeJS.ReadableStream) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,6 @@
 
 import express from 'express';
 import cors from 'cors';
-import net from 'net';
 import path from 'path';
 import fs from 'fs/promises';
 import { fileURLToPath } from 'url';
@@ -23,8 +22,8 @@ import {
   getDockerConnectionInfo,
   expandHomePath,
   readContainerLogs,
-  isRunningInsideDocker,
-  probeHostBitcoinSocketWithDocker
+
+  probeBitcoinSocketWithDocker
 } from './docker.js';
 import { getLogDiagnostics, getLogStreams, readCollatedLogLines } from './logs/diagnostics.js';
 
@@ -103,10 +102,10 @@ app.get('/api/status', async (_req, res) => {
   try {
     const state = await loadState();
     const containers = await getStackStatus(state.mode);
-    
+
     const running = state.mode === 'jd'
       ? (containers.translator?.status === 'healthy' || containers.translator?.status === 'starting') &&
-        (containers.jdc?.status === 'healthy' || containers.jdc?.status === 'starting')
+      (containers.jdc?.status === 'healthy' || containers.jdc?.status === 'starting')
       : (containers.translator?.status === 'healthy' || containers.translator?.status === 'starting');
 
     const response: StatusResponse = {
@@ -143,82 +142,28 @@ app.get('/api/config', async (_req, res) => {
   }
 });
 
-/**
- * Try to open the Unix socket to confirm something is actually listening.
- * Filesystem checks are not enough — Bitcoin Core leaves its socket file on
- * disk after a crash, so stat() would return a stale "valid" result.
- */
-function probeUnixSocket(socketPath: string, timeoutMs = 1000): Promise<{ valid: true } | { valid: false; error: string }> {
-  return new Promise((resolve) => {
-    const socket = net.createConnection({ path: socketPath });
-    let settled = false;
-    const finish = (result: { valid: true } | { valid: false; error: string }) => {
-      if (settled) return;
-      settled = true;
-      socket.destroy();
-      resolve(result);
-    };
-
-    socket.setTimeout(timeoutMs);
-    socket.once('connect', () => finish({ valid: true }));
-    socket.once('timeout', () => finish({
-      valid: false,
-      error: `Socket did not respond within ${timeoutMs}ms. Bitcoin Core may be unresponsive.`,
-    }));
-    socket.once('error', (err: NodeJS.ErrnoException) => {
-      switch (err.code) {
-        case 'ENOENT':
-          finish({ valid: false, error: `Socket not found at ${socketPath}. Make sure Bitcoin Core is running with IPC enabled.` });
-          break;
-        case 'ECONNREFUSED':
-          finish({ valid: false, error: `Socket file exists at ${socketPath} but nothing is listening. Bitcoin Core may have crashed or been stopped.` });
-          break;
-        case 'EACCES':
-          finish({ valid: false, error: `Permission denied for ${socketPath}. Check that the sv2-ui process can read this file.` });
-          break;
-        case 'ENOTSOCK':
-          finish({ valid: false, error: `Path ${socketPath} is not a Unix socket.` });
-          break;
-        default:
-          finish({ valid: false, error: err.message || 'Unknown error connecting to socket' });
-      }
-    });
-  });
-}
 
 /**
  * POST /api/validate/bitcoin-socket - Check if a Bitcoin Core IPC socket is listening
  */
 app.post('/api/validate/bitcoin-socket', async (req, res) => {
-  const { socket_path, network } = req.body;
+  const { socket_path } = req.body;
   if (!socket_path || typeof socket_path !== 'string') {
     return res.status(400).json({ valid: false, error: 'socket_path is required' });
   }
 
-  const result = await validateBitcoinSocket(socket_path, {
-    network: network === 'mainnet' || network === 'testnet4' ? network : undefined,
-  });
+  const resolved = expandHomePath(socket_path);
+  const result = await probeBitcoinSocketWithDocker(resolved);
   return res.json(result);
 });
-
-async function validateBitcoinSocket(
-  socketPath: string,
-  options: { network?: 'mainnet' | 'testnet4' } = {}
-): Promise<{ valid: true } | { valid: false; error: string }> {
-  const resolved = expandHomePath(socketPath);
-  return isRunningInsideDocker()
-    ? await probeHostBitcoinSocketWithDocker(resolved, 1000, options)
-    : await probeUnixSocket(resolved);
-}
 
 async function getBitcoinSocketStartupError(data: SetupData): Promise<string | null> {
   if (data.mode !== 'jd' || !data.bitcoin) {
     return null;
   }
 
-  const result = await validateBitcoinSocket(data.bitcoin.socket_path, {
-    network: data.bitcoin.network,
-  });
+  const resolved = expandHomePath(data.bitcoin.socket_path);
+  const result = await probeBitcoinSocketWithDocker(resolved);
   return result.valid ? null : result.error;
 }
 
@@ -455,9 +400,9 @@ app.post('/api/setup', async (req, res) => {
     res.json(response);
   } catch (error) {
     console.error('Setup error:', error);
-    const response: SetupResponse = { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Unknown error' 
+    const response: SetupResponse = {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
     };
     res.status(500).json(response);
   }
@@ -500,7 +445,7 @@ app.post('/api/restart', async (_req, res) => {
 
     await stopStack();
     await startStack(state.data, CONFIG_DIR);
-    
+
     res.json({ success: true });
   } catch (error) {
     console.error('Restart error:', error);
@@ -515,14 +460,14 @@ app.post('/api/reset', async (_req, res) => {
   try {
     // Stop containers first
     await stopStack();
-    
+
     // Delete state file
     try {
       await fs.unlink(STATE_FILE);
     } catch {
       // File might not exist, that's fine
     }
-    
+
     // Delete config files
     try {
       await fs.unlink(path.join(CONFIG_DIR, 'translator.toml'));
@@ -530,7 +475,7 @@ app.post('/api/reset', async (_req, res) => {
     } catch {
       // Files might not exist
     }
-    
+
     res.json({ success: true });
   } catch (error) {
     console.error('Reset error:', error);
@@ -603,7 +548,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 app.listen(PORT, () => {
   const dockerConnection = getDockerConnectionInfo();
-  
+
   console.log(`sv2-ui server running on http://localhost:${PORT}`);
   console.log(`Config directory: ${CONFIG_DIR}`);
   console.log(`Docker: ${dockerConnection.endpoint} (${dockerConnection.source})`);


### PR DESCRIPTION
closes #158

This PR refactors the validation flow introduced in #147 with the goal of simplifying the implementation, reducing duplicated logic, and making the behavior more consistent across environments.

* Unified, simplified, and extracted the validation logic into its own module: `server/src/bitcoin-socket-validator.ts`.
* Switched the helper container to use the lightweight `node:20-bookworm-slim` image directly instead of relying on the `sv2-ui` image
* Added an explicit image pull step before container creation
  * This fixes failures in environments such as `dind`, where the image may not already exist locally
  * It also allows removal of additional complexity from the Umbrel package
* Optimized image pulling by skipping the pull when the image already exists locally
* Removed the conditional logic that switched between direct host validation and Docker-based validation

  * Validation now consistently uses the helper container approach in both development and production environments

This refactor should not introduce any UI behavior changes.

As sanity check, I recommend testing the following scenarios:

#### 1. Development mode

Run the project using:

```bash
npm run dev
```

Then verify that Bitcoin node socket validation behaves correctly when the node is:

* running
* stopped/unreachable

#### 2. Containerized mode

Build the image:

```bash
docker build -t sv2-ui:pr-test .
```

Run the container:

```bash
docker run --rm \
  --name sv2-ui \
  -p 8080:8080 \
  -e HOST_HOME="$HOME" \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v sv2-config:/app/data/config \
  sv2-ui:pr-test
```

Then repeat the same socket validation checks to confirm the behavior also works correctly from inside a containerized environment.
This will also pave the way for me to start the RPC validatiosn.

I tested both approaches locally on macOS and everything appears to be working correctly.


