### PR TITLE
add auto start of containers

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,7 +38,9 @@ const STATE_FILE = path.join(CONFIG_DIR, 'state.json');
 
 const AUTO_START_RETRY_INTERVAL_MS = 30_000;
 
-let isAutoStarting = false;
+type StackBusyReason = 'auto-start' | 'manual';
+
+let stackBusyReason: StackBusyReason | null = null;
 
 type SavedState = {
   configured: boolean;
@@ -125,8 +127,25 @@ function isStackRunning(
     : healthyOrStarting(containers.translator?.status);
 }
 
-function autoStartBusyResponse() {
-  return { success: false, error: 'Mining services are already starting. Please wait.' };
+function beginStackOperation(reason: StackBusyReason): boolean {
+  if (stackBusyReason) return false;
+  stackBusyReason = reason;
+  return true;
+}
+
+function finishStackOperation(reason: StackBusyReason): void {
+  if (stackBusyReason === reason) {
+    stackBusyReason = null;
+  }
+}
+
+function stackBusyResponse() {
+  return {
+    success: false,
+    error: stackBusyReason === 'auto-start'
+      ? 'Mining services are already starting. Please wait.'
+      : 'Mining services are busy. Please wait.',
+  };
 }
 
 /**
@@ -151,7 +170,7 @@ app.get('/api/status', async (_req, res) => {
     const response: StatusResponse = {
       configured: state.configured,
       running: isStackRunning(state.mode, containers),
-      autoStarting: isAutoStarting,
+      autoStarting: stackBusyReason === 'auto-start',
       shouldBeRunning: state.shouldBeRunning,
       miningMode: state.miningMode,
       mode: state.mode,
@@ -228,11 +247,11 @@ async function getBitcoinSocketStartupError(data: SetupData): Promise<string | n
  * PUT /api/config - Update configuration and restart with new values
  */
 app.put('/api/config', async (req, res) => {
-  try {
-    if (isAutoStarting) {
-      return res.status(409).json(autoStartBusyResponse());
-    }
+  if (!beginStackOperation('manual')) {
+    return res.status(409).json(stackBusyResponse());
+  }
 
+  try {
     const state = await loadState();
 
     if (!state.configured || !state.data) {
@@ -324,6 +343,8 @@ app.put('/api/config', async (req, res) => {
       error: error instanceof Error ? error.message : 'Failed to update config',
     };
     res.status(500).json(response);
+  } finally {
+    finishStackOperation('manual');
   }
 });
 
@@ -383,11 +404,11 @@ app.get('/api/logs/raw', async (req, res) => {
  * POST /api/setup - Configure and start the stack
  */
 app.post('/api/setup', async (req, res) => {
-  try {
-    if (isAutoStarting) {
-      return res.status(409).json(autoStartBusyResponse());
-    }
+  if (!beginStackOperation('manual')) {
+    return res.status(409).json(stackBusyResponse());
+  }
 
+  try {
     const data = normalizeSetupData(req.body as SetupData);
     const requiresPool = !(data.miningMode === 'solo' && data.mode === 'jd');
 
@@ -470,6 +491,8 @@ app.post('/api/setup', async (req, res) => {
       error: error instanceof Error ? error.message : 'Unknown error'
     };
     res.status(500).json(response);
+  } finally {
+    finishStackOperation('manual');
   }
 });
 
@@ -477,19 +500,21 @@ app.post('/api/setup', async (req, res) => {
  * POST /api/stop - Stop the stack
  */
 app.post('/api/stop', async (_req, res) => {
-  try {
-    if (isAutoStarting) {
-      return res.status(409).json(autoStartBusyResponse());
-    }
-    await stopStack();
+  if (!beginStackOperation('manual')) {
+    return res.status(409).json(stackBusyResponse());
+  }
 
+  try {
     const state = await loadState();
     if (state.configured && state.data) await saveState(state.data, false);
 
+    await stopStack();
     res.json({ success: true });
   } catch (error) {
     console.error('Stop error:', error);
     res.status(500).json({ success: false, error: 'Failed to stop stack' });
+  } finally {
+    finishStackOperation('manual');
   }
 });
 
@@ -497,11 +522,11 @@ app.post('/api/stop', async (_req, res) => {
  * POST /api/restart - Restart the stack
  */
 app.post('/api/restart', async (_req, res) => {
-  try {
-    if (isAutoStarting) {
-      return res.status(409).json(autoStartBusyResponse());
-    }
+  if (!beginStackOperation('manual')) {
+    return res.status(409).json(stackBusyResponse());
+  }
 
+  try {
     const state = await loadState();
     if (!state.configured || !state.data) {
       return res.status(400).json({ success: false, error: 'Not configured' });
@@ -528,6 +553,8 @@ app.post('/api/restart', async (_req, res) => {
   } catch (error) {
     console.error('Restart error:', error);
     res.status(500).json({ success: false, error: 'Failed to restart stack' });
+  } finally {
+    finishStackOperation('manual');
   }
 });
 
@@ -535,11 +562,11 @@ app.post('/api/restart', async (_req, res) => {
  * POST /api/reset - Reset configuration (stop containers and delete config)
  */
 app.post('/api/reset', async (_req, res) => {
-  try {
-    if (isAutoStarting) {
-      return res.status(409).json(autoStartBusyResponse());
-    }
+  if (!beginStackOperation('manual')) {
+    return res.status(409).json(stackBusyResponse());
+  }
 
+  try {
     // Stop containers first
     await stopStack();
 
@@ -562,6 +589,8 @@ app.post('/api/reset', async (_req, res) => {
   } catch (error) {
     console.error('Reset error:', error);
     res.status(500).json({ success: false, error: 'Failed to reset configuration' });
+  } finally {
+    finishStackOperation('manual');
   }
 });
 
@@ -626,9 +655,8 @@ app.get('*', (_req, res) => {
 });
 
 async function reconcileShouldBeRunning(): Promise<void> {
-  if (isAutoStarting) return;
+  if (!beginStackOperation('auto-start')) return;
 
-  isAutoStarting = true;
   try {
     const state = await loadState();
     if (!state.configured || !state.data || !state.shouldBeRunning) return;
@@ -657,7 +685,7 @@ async function reconcileShouldBeRunning(): Promise<void> {
   } catch (error) {
     console.error('Auto-start failed:', error);
   } finally {
-    isAutoStarting = false;
+    finishStackOperation('auto-start');
   }
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,8 @@ const PORT = process.env.PORT || 3001;
 const CONFIG_DIR = process.env.CONFIG_DIR || path.join(__dirname, '../../data/config');
 const STATE_FILE = path.join(CONFIG_DIR, 'state.json');
 
+let isAutoStarting = false;
+
 // Middleware
 app.use(cors());
 app.use(express.json());
@@ -112,6 +114,7 @@ app.get('/api/status', async (_req, res) => {
     const response: StatusResponse = {
       configured: state.configured,
       running,
+      autoStarting: isAutoStarting,
       miningMode: state.miningMode,
       mode: state.mode,
       poolName: state.data?.miningMode === 'solo' && state.data?.mode === 'jd'
@@ -442,6 +445,10 @@ app.post('/api/stop', async (_req, res) => {
  */
 app.post('/api/restart', async (_req, res) => {
   try {
+    if (isAutoStarting) {
+      return res.status(409).json({ success: false, error: 'Mining services are already starting. Please wait.' });
+    }
+
     const state = await loadState();
     if (!state.configured || !state.data) {
       return res.status(400).json({ success: false, error: 'Not configured' });
@@ -559,6 +566,53 @@ app.get('*', (_req, res) => {
   res.sendFile(path.join(UI_DIR, 'index.html'));
 });
 
+async function autoStartIfConfigured(): Promise<void> {
+  isAutoStarting = true;
+  try {
+    const state = await loadState();
+    if (!state.configured || !state.data) {
+      console.log('Auto-start skipped: not configured');
+      return;
+    }
+
+    const containers = await getStackStatus(state.mode);
+    const bothHealthyOrStarting = (status: string | undefined) =>
+      status === 'healthy' || status === 'starting';
+    const alreadyRunning = state.mode === 'jd'
+      ? bothHealthyOrStarting(containers.translator?.status) &&
+      bothHealthyOrStarting(containers.jdc?.status)
+      : bothHealthyOrStarting(containers.translator?.status);
+
+    if (alreadyRunning) {
+      console.log('Auto-start skipped: containers already running');
+      return;
+    }
+
+    console.log('Auto-start: configured but stopped — starting containers...');
+
+    const versionError = getBitcoinCoreVersionError(state.data);
+    if (versionError) {
+      console.error('Auto-start aborted:', versionError);
+      return;
+    }
+
+    if (state.data.mode === 'jd') {
+      const socketError = await getBitcoinSocketStartupError(state.data);
+      if (socketError) {
+        console.error('Auto-start aborted:', socketError);
+        return;
+      }
+    }
+
+    await startStack(state.data, CONFIG_DIR);
+    console.log('Auto-start: containers started successfully');
+  } catch (error) {
+    console.error('Auto-start failed:', error);
+  } finally {
+    isAutoStarting = false;
+  }
+}
+
 // Start server
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -580,6 +634,9 @@ app.listen(PORT, () => {
     console.log('└─────────────────────────────────────────────────────┘');
     console.log('');
   }
+
+  // fire-and-forget: restart the mining stack if configured but stopped
+  autoStartIfConfigured();
 });
 
 // Graceful shutdown: stop mining containers when sv2-ui exits

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -151,7 +151,7 @@ app.get('/api/config', async (_req, res) => {
  * GET /api/env - Host environment variables relevant to the UI
  */
 app.get('/api/env', (_req, res) => {
-  res.json({ HOST_OS: process.env.HOST_OS || null });
+  res.json({ HOST_OS: process.env.HOST_OS || null, STRATUM_HOST: process.env.STRATUM_HOST || null });
 });
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,7 +36,17 @@ const PORT = process.env.PORT || 3001;
 const CONFIG_DIR = process.env.CONFIG_DIR || path.join(__dirname, '../../data/config');
 const STATE_FILE = path.join(CONFIG_DIR, 'state.json');
 
+const AUTO_START_RETRY_INTERVAL_MS = 30_000;
+
 let isAutoStarting = false;
+
+type SavedState = {
+  configured: boolean;
+  miningMode: 'solo' | 'pool' | null;
+  mode: 'jd' | 'no-jd' | null;
+  data: SetupData | null;
+  shouldBeRunning: boolean;
+};
 
 // Middleware
 app.use(cors());
@@ -53,25 +63,41 @@ app.use(express.static(UI_DIR));
 /**
  * Load saved state
  */
-async function loadState(): Promise<{ configured: boolean; miningMode: 'solo' | 'pool' | null; mode: 'jd' | 'no-jd' | null; data: SetupData | null }> {
+function getDefaultState(): SavedState {
+  return { configured: false, miningMode: null, mode: null, data: null, shouldBeRunning: false };
+}
+
+function normalizeSavedState(state: Partial<SavedState>): SavedState {
+  const configured = state.configured ?? false;
+  return {
+    configured,
+    miningMode: state.miningMode ?? null,
+    mode: state.mode ?? null,
+    data: state.data ?? null,
+    shouldBeRunning: state.shouldBeRunning ?? configured,
+  };
+}
+
+async function loadState(): Promise<SavedState> {
   try {
     const content = await fs.readFile(STATE_FILE, 'utf-8');
-    return JSON.parse(content);
+    return normalizeSavedState(JSON.parse(content) as Partial<SavedState>);
   } catch {
-    return { configured: false, miningMode: null, mode: null, data: null };
+    return getDefaultState();
   }
 }
 
 /**
  * Save state
  */
-async function saveState(data: SetupData): Promise<void> {
+async function saveState(data: SetupData, shouldBeRunning = true): Promise<void> {
   await fs.mkdir(CONFIG_DIR, { recursive: true });
   await fs.writeFile(STATE_FILE, JSON.stringify({
     configured: true,
     miningMode: data.miningMode,
     mode: data.mode,
     data,
+    shouldBeRunning,
   }, null, 2));
 }
 
@@ -85,6 +111,22 @@ function getBitcoinCoreVersionError(data: SetupData): string | null {
   }
 
   return null;
+}
+
+function isStackRunning(
+  mode: SavedState['mode'],
+  containers: StatusResponse['containers']
+): boolean {
+  const healthyOrStarting = (status: string | undefined) =>
+    status === 'healthy' || status === 'starting';
+
+  return mode === 'jd'
+    ? healthyOrStarting(containers.translator?.status) && healthyOrStarting(containers.jdc?.status)
+    : healthyOrStarting(containers.translator?.status);
+}
+
+function autoStartBusyResponse() {
+  return { success: false, error: 'Mining services are already starting. Please wait.' };
 }
 
 /**
@@ -106,15 +148,11 @@ app.get('/api/status', async (_req, res) => {
     const state = await loadState();
     const containers = await getStackStatus(state.mode);
 
-    const running = state.mode === 'jd'
-      ? (containers.translator?.status === 'healthy' || containers.translator?.status === 'starting') &&
-      (containers.jdc?.status === 'healthy' || containers.jdc?.status === 'starting')
-      : (containers.translator?.status === 'healthy' || containers.translator?.status === 'starting');
-
     const response: StatusResponse = {
       configured: state.configured,
-      running,
+      running: isStackRunning(state.mode, containers),
       autoStarting: isAutoStarting,
+      shouldBeRunning: state.shouldBeRunning,
       miningMode: state.miningMode,
       mode: state.mode,
       poolName: state.data?.miningMode === 'solo' && state.data?.mode === 'jd'
@@ -191,6 +229,10 @@ async function getBitcoinSocketStartupError(data: SetupData): Promise<string | n
  */
 app.put('/api/config', async (req, res) => {
   try {
+    if (isAutoStarting) {
+      return res.status(409).json(autoStartBusyResponse());
+    }
+
     const state = await loadState();
 
     if (!state.configured || !state.data) {
@@ -342,6 +384,10 @@ app.get('/api/logs/raw', async (req, res) => {
  */
 app.post('/api/setup', async (req, res) => {
   try {
+    if (isAutoStarting) {
+      return res.status(409).json(autoStartBusyResponse());
+    }
+
     const data = normalizeSetupData(req.body as SetupData);
     const requiresPool = !(data.miningMode === 'solo' && data.mode === 'jd');
 
@@ -432,7 +478,14 @@ app.post('/api/setup', async (req, res) => {
  */
 app.post('/api/stop', async (_req, res) => {
   try {
+    if (isAutoStarting) {
+      return res.status(409).json(autoStartBusyResponse());
+    }
     await stopStack();
+
+    const state = await loadState();
+    if (state.configured && state.data) await saveState(state.data, false);
+
     res.json({ success: true });
   } catch (error) {
     console.error('Stop error:', error);
@@ -446,13 +499,15 @@ app.post('/api/stop', async (_req, res) => {
 app.post('/api/restart', async (_req, res) => {
   try {
     if (isAutoStarting) {
-      return res.status(409).json({ success: false, error: 'Mining services are already starting. Please wait.' });
+      return res.status(409).json(autoStartBusyResponse());
     }
 
     const state = await loadState();
     if (!state.configured || !state.data) {
       return res.status(400).json({ success: false, error: 'Not configured' });
     }
+
+    await saveState(state.data, true);
 
     const bitcoinCoreVersionError = getBitcoinCoreVersionError(state.data);
     if (bitcoinCoreVersionError) {
@@ -481,6 +536,10 @@ app.post('/api/restart', async (_req, res) => {
  */
 app.post('/api/reset', async (_req, res) => {
   try {
+    if (isAutoStarting) {
+      return res.status(409).json(autoStartBusyResponse());
+    }
+
     // Stop containers first
     await stopStack();
 
@@ -566,40 +625,29 @@ app.get('*', (_req, res) => {
   res.sendFile(path.join(UI_DIR, 'index.html'));
 });
 
-async function autoStartIfConfigured(): Promise<void> {
+async function reconcileShouldBeRunning(): Promise<void> {
+  if (isAutoStarting) return;
+
   isAutoStarting = true;
   try {
     const state = await loadState();
-    if (!state.configured || !state.data) {
-      console.log('Auto-start skipped: not configured');
-      return;
-    }
+    if (!state.configured || !state.data || !state.shouldBeRunning) return;
 
     const containers = await getStackStatus(state.mode);
-    const bothHealthyOrStarting = (status: string | undefined) =>
-      status === 'healthy' || status === 'starting';
-    const alreadyRunning = state.mode === 'jd'
-      ? bothHealthyOrStarting(containers.translator?.status) &&
-      bothHealthyOrStarting(containers.jdc?.status)
-      : bothHealthyOrStarting(containers.translator?.status);
+    if (isStackRunning(state.mode, containers)) return;
 
-    if (alreadyRunning) {
-      console.log('Auto-start skipped: containers already running');
-      return;
-    }
-
-    console.log('Auto-start: configured but stopped — starting containers...');
+    console.log('Auto-start: shouldBeRunning=true and stack is stopped. Starting containers...');
 
     const versionError = getBitcoinCoreVersionError(state.data);
     if (versionError) {
-      console.error('Auto-start aborted:', versionError);
+      console.error('Auto-start blocked:', versionError);
       return;
     }
 
     if (state.data.mode === 'jd') {
       const socketError = await getBitcoinSocketStartupError(state.data);
       if (socketError) {
-        console.error('Auto-start aborted:', socketError);
+        console.error('Auto-start blocked:', socketError);
         return;
       }
     }
@@ -635,8 +683,11 @@ app.listen(PORT, () => {
     console.log('');
   }
 
-  // fire-and-forget: restart the mining stack if configured but stopped
-  autoStartIfConfigured();
+  // Keep configured mining services running across app/system restarts.
+  void reconcileShouldBeRunning();
+  setInterval(() => {
+    void reconcileShouldBeRunning();
+  }, AUTO_START_RETRY_INTERVAL_MS);
 });
 
 // Graceful shutdown: stop mining containers when sv2-ui exits

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -12,6 +12,7 @@ export interface ContainerStatus {
 export interface StatusResponse {
   configured: boolean;
   running: boolean;
+  autoStarting?: boolean;
   miningMode: MiningMode | null;
   mode: SetupMode | null;
   poolName: string | null;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -13,6 +13,7 @@ export interface StatusResponse {
   configured: boolean;
   running: boolean;
   autoStarting?: boolean;
+  shouldBeRunning?: boolean;
   miningMode: MiningMode | null;
   mode: SetupMode | null;
   poolName: string | null;

--- a/src/components/setup/MinerConnectionInfo.tsx
+++ b/src/components/setup/MinerConnectionInfo.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { TRANSLATOR_PORT, JDC_PORT, JDC_AUTHORITY_PUBLIC_KEY } from '@/lib/ports';
+import { useHostEnv } from '@/hooks/useHostEnv';
 
 function CopyableAddress({ address }: { address: string }) {
   const [copied, setCopied] = useState(false);
@@ -31,8 +32,10 @@ interface MinerConnectionInfoProps {
 }
 
 export function MinerConnectionInfo({ isJdMode, centered = false }: MinerConnectionInfoProps) {
-  const translatorUrl = `stratum+tcp://<your-machine-ip>:${TRANSLATOR_PORT}`;
-  const jdcUrl = `stratum2+tcp://<your-machine-ip>:${JDC_PORT}/${JDC_AUTHORITY_PUBLIC_KEY}`;
+  const { stratumHost } = useHostEnv();
+  const host = stratumHost ?? '<your-machine-ip>';
+  const translatorUrl = `stratum+tcp://${host}:${TRANSLATOR_PORT}`;
+  const jdcUrl = `stratum2+tcp://${host}:${JDC_PORT}/${JDC_AUTHORITY_PUBLIC_KEY}`;
 
   const hint = (
     <p className="text-xs text-muted-foreground">
@@ -54,7 +57,7 @@ export function MinerConnectionInfo({ isJdMode, centered = false }: MinerConnect
         <div className="font-semibold text-sm">SV1 Firmware</div>
         <div className="text-xs text-muted-foreground">Point to the Translator Proxy</div>
         <CopyableAddress address={translatorUrl} />
-        {hint}
+        {!stratumHost && hint}
       </div>
 
       {isJdMode && (
@@ -62,7 +65,7 @@ export function MinerConnectionInfo({ isJdMode, centered = false }: MinerConnect
           <div className="font-semibold text-sm">SV2 Firmware</div>
           <div className="text-xs text-muted-foreground">Point directly to the JD Client</div>
           <CopyableAddress address={jdcUrl} />
-          {hint}
+          {!stratumHost && hint}
         </div>
       )}
     </div>

--- a/src/hooks/useHostEnv.ts
+++ b/src/hooks/useHostEnv.ts
@@ -2,10 +2,12 @@ import { useState, useEffect } from 'react';
 
 interface HostEnv {
   HOST_OS: string | null;
+  STRATUM_HOST: string | null;
 }
 
 export function useHostEnv() {
   const [hostOs, setHostOs] = useState<string | null>(null);
+  const [stratumHost, setStratumHost] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -15,6 +17,7 @@ export function useHostEnv() {
       .then(data => {
         if (!cancelled) {
           setHostOs(data.HOST_OS);
+          setStratumHost(data.STRATUM_HOST);
           setIsLoading(false);
         }
       })
@@ -26,5 +29,5 @@ export function useHostEnv() {
     return () => { cancelled = true; };
   }, []);
 
-  return { hostOs, isLoading };
+  return { hostOs, stratumHost, isLoading };
 }

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 export interface SetupStatus {
   configured: boolean;
   running: boolean;
+  autoStarting?: boolean;
   miningMode: 'solo' | 'pool' | null;
   mode: 'jd' | 'no-jd' | null;
   poolName: string | null;
@@ -69,6 +70,7 @@ export function useSetupStatus() {
     isOrchestrated: status !== null && status !== undefined,
     isConfigured: status?.configured ?? false,
     isRunning: status?.running ?? false,
+    autoStarting: status?.autoStarting ?? false,
     miningMode: status?.miningMode ?? null,
     mode: status?.mode ?? null,
     poolName: status?.poolName ?? null,

--- a/src/hooks/useSetupStatus.ts
+++ b/src/hooks/useSetupStatus.ts
@@ -4,6 +4,7 @@ export interface SetupStatus {
   configured: boolean;
   running: boolean;
   autoStarting?: boolean;
+  shouldBeRunning?: boolean;
   miningMode: 'solo' | 'pool' | null;
   mode: 'jd' | 'no-jd' | null;
   poolName: string | null;
@@ -71,6 +72,7 @@ export function useSetupStatus() {
     isConfigured: status?.configured ?? false,
     isRunning: status?.running ?? false,
     autoStarting: status?.autoStarting ?? false,
+    shouldBeRunning: status?.shouldBeRunning ?? false,
     miningMode: status?.miningMode ?? null,
     mode: status?.mode ?? null,
     poolName: status?.poolName ?? null,

--- a/src/pages/UnifiedDashboard.tsx
+++ b/src/pages/UnifiedDashboard.tsx
@@ -78,6 +78,7 @@ export function UnifiedDashboard() {
     isOrchestrated,
     isConfigured,
     isRunning,
+    autoStarting,
     miningMode,
     mode: templateMode,
     poolName: configPoolName,
@@ -497,23 +498,28 @@ export function UnifiedDashboard() {
       {configuredButStopped && showError && (
         <div className="flex flex-col gap-3 rounded-xl border border-primary/40 bg-primary/10 px-5 py-4 text-sm sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <Play className="h-4 w-4 shrink-0 text-primary" />
-            <span>Mining services are stopped.</span>
-          </div>
-          <button
-            onClick={handleStartMining}
-            disabled={isStarting}
-            className="flex h-9 items-center gap-2 self-start rounded-full bg-primary px-4 font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 sm:self-auto"
-          >
-            {isStarting ? (
-              <>
-                <div className="h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
-                Starting...
-              </>
+            {autoStarting || isStarting ? (
+              <div className="h-4 w-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
             ) : (
-              'Start Mining'
+              <Play className="h-4 w-4 shrink-0 text-primary" />
             )}
-          </button>
+            <span>
+              {autoStarting
+                ? 'Mining services are starting...'
+                : isStarting
+                  ? 'Starting mining services...'
+                  : 'Mining services are stopped.'}
+            </span>
+          </div>
+          {!autoStarting && !isStarting && (
+            <button
+              onClick={handleStartMining}
+              disabled={isStarting}
+              className="flex h-9 items-center gap-2 self-start rounded-full bg-primary px-4 font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 sm:self-auto"
+            >
+              Start Mining
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
closes #181 and #182 

this is adding and auto-start script when the backend starts to check if it is possible to restart the container automatically.


now if the env var `STRATUM_HOST` is detected it replaces the instructions on the dashboard:
<img width="2466" height="372" alt="image" src="https://github.com/user-attachments/assets/43e52ae2-5435-4e26-8a27-2276753cdae3" />


`export STRATUM_HOST=google.dev && npm run dev && unset STRATUM_HOST`

there is no validation on the string that will be applied just a direct replace.

So we could set this as `umbrel.local` or a direct IP depending on the case