### PR TITLE
Add ability to configure coinbase verification in UI

### DIFF
--- a/server/src/config-generator.test.ts
+++ b/server/src/config-generator.test.ts
@@ -74,10 +74,10 @@ test('translator config uses advanced setup values', () => {
   assert.match(config, /shares_per_minute = 12\.5/);
 });
 
-test('translator config keeps payout verification disabled for pool mining', () => {
+test('translator config omits payout verification for pool mining', () => {
   const config = generateTranslatorConfig(BASE_DATA_30);
 
-  assert.match(config, /verify_payout = false/);
+  assert.doesNotMatch(config, /verify_payout/);
 });
 
 test('translator config enables payout verification for solo pool mining', () => {
@@ -95,6 +95,24 @@ test('translator config enables payout verification for solo pool mining', () =>
   assert.match(config, /verify_payout = true/);
 });
 
+test('translator config allows payout verification to be disabled for solo pool mining', () => {
+  const config = generateTranslatorConfig({
+    ...BASE_DATA_30,
+    miningMode: 'solo',
+    mode: 'no-jd',
+    pool: {
+      ...BASE_DATA_30.pool!,
+      user_identity: 'tb1qexample',
+    },
+    translator: {
+      ...BASE_DATA_30.translator!,
+      verify_payout: false,
+    },
+  });
+
+  assert.match(config, /verify_payout = false/);
+});
+
 test('translator config disables payout verification for full donation solo identities', () => {
   const config = generateTranslatorConfig({
     ...BASE_DATA_30,
@@ -110,7 +128,7 @@ test('translator config disables payout verification for full donation solo iden
   assert.match(config, /verify_payout = false/);
 });
 
-test('translator config keeps payout verification disabled for sovereign solo mining', () => {
+test('translator config omits payout verification for sovereign solo mining', () => {
   const config = generateTranslatorConfig({
     ...BASE_DATA_30,
     miningMode: 'solo',
@@ -123,7 +141,7 @@ test('translator config keeps payout verification disabled for sovereign solo mi
   });
 
   assert.match(config, /user_identity = "solo_miner"/);
-  assert.match(config, /verify_payout = false/);
+  assert.doesNotMatch(config, /verify_payout/);
 });
 
 test('jdc config uses shared shares-per-minute and miner signature', () => {
@@ -149,6 +167,22 @@ test('normalization backfills advanced defaults for old saved configs', () => {
   assert.ok(normalized.translator);
   assert.equal(normalized.translator.shares_per_minute, 6);
   assert.equal(normalized.translator.downstream_extranonce2_size, 4);
+  assert.equal('verify_payout' in normalized.translator, false);
+});
+
+test('normalization backfills payout verification only for solo pool mining', () => {
+  const normalized = normalizeSetupData({
+    ...BASE_DATA_30,
+    miningMode: 'solo',
+    mode: 'no-jd',
+    pool: {
+      ...BASE_DATA_30.pool!,
+      user_identity: 'tb1qexample',
+    },
+  });
+
+  assert.ok(normalized.translator);
+  assert.equal(normalized.translator.verify_payout, true);
 });
 
 test('normalization migrates legacy translator identity into primary and fallback pools', () => {

--- a/server/src/config-generator.ts
+++ b/server/src/config-generator.ts
@@ -90,13 +90,16 @@ function shouldVerifyPayout(data: SetupData): boolean {
   }
 
   const pools = upstreamPools(data);
-  return pools.length > 0 && pools.every((pool) => !isFullDonationIdentity(pool.user_identity));
+  return data.translator?.verify_payout !== false
+    && pools.length > 0
+    && pools.every((pool) => !isFullDonationIdentity(pool.user_identity));
 }
 
 export function normalizeSetupData(data: SetupData): SetupData {
   const fallbackIdentity = legacyIdentity(data);
   const pool = normalizePool(data.pool, fallbackIdentity);
   const fallbackPools = normalizeFallbackPools(data, fallbackIdentity);
+  const isSoloPool = data.miningMode === 'solo' && data.mode === 'no-jd';
   const legacyData = data as SetupData & {
     jdc?: (JdcConfig & { user_identity?: string }) | null;
   };
@@ -133,6 +136,7 @@ export function normalizeSetupData(data: SetupData): SetupData {
     translator: {
       enable_vardiff: data.translator.enable_vardiff,
       aggregate_channels: shouldAggregateTranslatorChannelsForPools([pool, ...fallbackPools]),
+      ...(isSoloPool ? { verify_payout: data.translator.verify_payout ?? true } : {}),
       min_hashrate: data.translator.min_hashrate,
       shares_per_minute: positiveNumber(data.translator.shares_per_minute, DEFAULT_SHARES_PER_MINUTE),
       downstream_extranonce2_size: positiveInteger(
@@ -151,6 +155,7 @@ export function generateTranslatorConfig(data: SetupData): string {
   const { pool, translator, mode, jdc } = normalizedData;
   const isJdMode = mode === 'jd';
   const isSovereignSolo = normalizedData.miningMode === 'solo' && isJdMode;
+  const isSoloPool = normalizedData.miningMode === 'solo' && mode === 'no-jd';
 
   if (!translator || (!isJdMode && !pool)) {
     throw new Error('Pool and translator configuration are required');
@@ -160,6 +165,12 @@ export function generateTranslatorConfig(data: SetupData): string {
   // Both containers are on sv2-network, so we can use the container name as hostname
   // (hostname resolution supported since sv2-apps PR #286)
   const verifyPayout = shouldVerifyPayout(normalizedData);
+  const verifyPayoutConfig = isSoloPool
+    ? `# Verify upstream coinbase outputs against the configured payout
+verify_payout = ${verifyPayout}
+
+`
+    : '';
 
   // Min hashrate from user config (default 100 TH/s if not set)
   const minHashrate = translator.min_hashrate ? `${translator.min_hashrate}.0` : '100_000_000_000_000.0';
@@ -202,9 +213,7 @@ min_supported_version = 2
 # Extranonce2 size for downstream connections
 downstream_extranonce2_size = ${downstreamExtranonce2Size}
 
-# Verify upstream coinbase outputs against the configured payout
-verify_payout = ${verifyPayout}
-
+${verifyPayoutConfig}
 # Aggregate channels: if true, all miners share one upstream channel
 aggregate_channels = ${translator.aggregate_channels}
 

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -32,6 +32,7 @@ export interface JdcConfig {
 export interface TranslatorConfig {
   enable_vardiff: boolean;
   aggregate_channels: boolean;
+  verify_payout?: boolean;
   min_hashrate: number;
   shares_per_minute: number;
   downstream_extranonce2_size: number;

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
 import { PoolIcon } from '@/components/ui/pool-icon';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
@@ -136,6 +137,7 @@ export function ConfigurationTab() {
   const [editAdvanced, setEditAdvanced] = useState<{
     shares_per_minute: string;
     downstream_extranonce2_size: string;
+    verify_payout?: boolean;
   } | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
@@ -236,11 +238,13 @@ export function ConfigurationTab() {
 
   const startEditAdvanced = () => {
     if (!config?.translator) return;
+    const configIsSoloPool = config.miningMode === 'solo' && config.mode === 'no-jd';
     setEditAdvanced({
       shares_per_minute: String(config.translator.shares_per_minute ?? DEFAULT_SHARES_PER_MINUTE),
       downstream_extranonce2_size: String(
         config.translator.downstream_extranonce2_size ?? DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE,
       ),
+      ...(configIsSoloPool ? { verify_payout: config.translator.verify_payout ?? true } : {}),
     });
     setEditing('advanced');
   };
@@ -305,9 +309,12 @@ export function ConfigurationTab() {
       updated.jdc = { ...config.jdc, jdc_signature: editSignature.trim() };
     } else if (editing === 'advanced') {
       if (!isAdvancedValid || !config.translator || !editAdvanced) return;
+      const configIsSoloPool = config.miningMode === 'solo' && config.mode === 'no-jd';
       updated.translator = {
-        ...config.translator,
         enable_vardiff: true,
+        aggregate_channels: config.translator.aggregate_channels,
+        ...(configIsSoloPool ? { verify_payout: editAdvanced.verify_payout ?? true } : {}),
+        min_hashrate: config.translator.min_hashrate,
         shares_per_minute: Number(editAdvanced.shares_per_minute),
         downstream_extranonce2_size: Number(editAdvanced.downstream_extranonce2_size),
       };
@@ -380,6 +387,7 @@ export function ConfigurationTab() {
   const isJdMode = activeMode === 'jd';
   const isSoloMode = activeMiningMode === 'solo';
   const isSovereignSolo = isSoloMode && isJdMode;
+  const isSoloPool = isSoloMode && activeMode === 'no-jd';
   const bitcoinCoreVersion = normalizeBitcoinCoreVersion(config.bitcoin?.core_version);
   const templateModeLabel = isSoloMode
     ? isJdMode
@@ -801,11 +809,39 @@ export function ConfigurationTab() {
                       {config.translator.downstream_extranonce2_size ?? DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE}
                     </span>
                   </p>
+                  {isSoloPool && (
+                    <p>
+                      Coinbase verification:{' '}
+                      <span className="font-mono text-foreground">
+                        {(config.translator.verify_payout ?? true) ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </p>
+                  )}
                 </div>
               }
               editContent={
                 editAdvanced && (
                   <div className="space-y-4">
+                    {isSoloPool && (
+                      <div className="flex items-center justify-between gap-4">
+                        <div className="space-y-0.5">
+                          <p id="edit-verify-payout-label" className="text-xs font-medium">
+                            Coinbase Verification
+                          </p>
+                          <p id="edit-verify-payout-desc" className="text-xs text-muted-foreground">
+                            Verify that your payout address is included in the pool&apos;s coinbase transaction.
+                          </p>
+                        </div>
+                        <Switch
+                          id="edit-verify-payout-switch"
+                          checked={editAdvanced.verify_payout ?? true}
+                          onCheckedChange={(checked) => setEditAdvanced({ ...editAdvanced, verify_payout: checked })}
+                          aria-labelledby="edit-verify-payout-label"
+                          aria-describedby="edit-verify-payout-desc"
+                        />
+                      </div>
+                    )}
+
                     <div>
                       <label htmlFor="edit-shares-per-minute" className="block text-xs font-medium mb-1">
                         Shares Per Minute

--- a/src/components/setup/steps/HashrateStep.tsx
+++ b/src/components/setup/steps/HashrateStep.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { StepProps } from '../types';
 import { Check, ChevronDown, Settings2 } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
 
 interface HashratePreset {
   id: string;
@@ -38,6 +39,7 @@ function formatHashrateDisplay(hashrate: number): string {
 }
 
 export function HashrateStep({ data, updateData, onNext }: StepProps) {
+  const isSoloPool = data.miningMode === 'solo' && data.mode === 'no-jd';
   const existingHashrate = data.translator?.min_hashrate || 0;
   const existingSharesPerMinute = data.translator?.shares_per_minute || DEFAULT_SHARES_PER_MINUTE;
   const existingDownstreamExtranonce2Size =
@@ -73,6 +75,7 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
   });
   const [inputError, setInputError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [verifyPayout, setVerifyPayout] = useState(data.translator?.verify_payout ?? true);
   const [sharesPerMinute, setSharesPerMinute] = useState(String(existingSharesPerMinute));
   const [downstreamExtranonce2Size, setDownstreamExtranonce2Size] = useState(
     String(existingDownstreamExtranonce2Size),
@@ -126,9 +129,9 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
   useEffect(() => {
     updateData({
       translator: {
-        ...data.translator,
         enable_vardiff: true,
         aggregate_channels: data.translator?.aggregate_channels ?? false,
+        ...(isSoloPool ? { verify_payout: verifyPayout } : {}),
         min_hashrate: hashrate,
         shares_per_minute: Number(sharesPerMinute) || DEFAULT_SHARES_PER_MINUTE,
         downstream_extranonce2_size:
@@ -137,7 +140,7 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
     });
   // intentionally excluded: data.translator and updateData cause infinite loop when included
     // eslint-disable-next-line react-hooks/exhaustive-deps
-}, [hashrate, sharesPerMinute, downstreamExtranonce2Size]);
+}, [hashrate, sharesPerMinute, downstreamExtranonce2Size, verifyPayout, isSoloPool]);
 
   return (
     <div className="space-y-8">
@@ -249,6 +252,24 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
 
         {showAdvanced && (
           <div className="border-t border-border p-4 space-y-4">
+            {isSoloPool && (
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <p id="verify-payout-label" className="text-sm font-medium">Coinbase Verification</p>
+                  <p id="verify-payout-desc" className="text-xs text-muted-foreground">
+                    Verify that your payout address is included in the pool&apos;s coinbase transaction.
+                  </p>
+                </div>
+                <Switch
+                  id="verify-payout-switch"
+                  checked={verifyPayout}
+                  onCheckedChange={setVerifyPayout}
+                  aria-labelledby="verify-payout-label"
+                  aria-describedby="verify-payout-desc"
+                />
+              </div>
+            )}
+
             <div>
               <label htmlFor="shares-per-minute" className="block text-sm font-medium mb-2">
                 Shares Per Minute

--- a/src/components/setup/steps/ReviewStart.tsx
+++ b/src/components/setup/steps/ReviewStart.tsx
@@ -349,6 +349,14 @@ export function ReviewStart({ data, onComplete, onGoToStep }: ReviewStartProps) 
                   {data.translator.downstream_extranonce2_size ?? 4}
                 </span>
               </div>
+              {data.miningMode === "solo" && data.mode === "no-jd" && (
+                <div>
+                  Coinbase verification:{" "}
+                  <span className="font-mono text-xs text-foreground">
+                    {(data.translator.verify_payout ?? true) ? "Enabled" : "Disabled"}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
This PR adds a Coinbase Verification toggle to Advanced Options for solo pool mining in both setup and Settings. It is enabled by default and controls` verify_payout`, allowing miners to turn off the check that their payout address appears in the pool’s coinbase transaction.
## Before
Always turned on by default 
<img width="480" height="751" alt="Screenshot 2026-07-13 at 13 57 55" src="https://github.com/user-attachments/assets/439fcaf0-ba32-4b44-8fb8-4a4e3156b274" />

## After
Enabled by default, optional to disable 

<img width="668" height="763" alt="Screenshot 2026-07-13 at 14 06 23" src="https://github.com/user-attachments/assets/64f9fee5-d5be-4f03-8cef-351cc79032f5" />

<img width="866" height="753" alt="Screenshot 2026-07-13 at 14 05 27" src="https://github.com/user-attachments/assets/8edd4743-55d9-4721-8ada-3b3bcd6d9608" />

<img width="861" height="714" alt="Screenshot 2026-07-13 at 14 07 00" src="https://github.com/user-attachments/assets/3a2e4087-e6f7-4284-aaed-e4a4368aa7be" />