### PR TITLE
Unify pool configuration flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9651,6 +9651,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@sv2-ui/shared": "*",
+        "bs58check": "^4.0.0",
         "cors": "^2.8.5",
         "dockerode": "^4.0.2",
         "express": "^4.18.2",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@sv2-ui/shared": "*",
+    "bs58check": "^4.0.0",
     "cors": "^2.8.5",
     "dockerode": "^4.0.2",
     "express": "^4.18.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from './docker.js';
 import { getLogDiagnostics, getLogStreams, readCollatedLogLines } from './logs/diagnostics.js';
 import { ActivePoolTracker } from './active-pool.js';
+import { getPoolConfigError, MAX_FALLBACK_POOLS } from './pool-validation.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
@@ -56,6 +57,10 @@ type SavedState = {
   data: SetupData | null;
   shouldBeRunning: boolean;
 };
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 // Middleware
 app.use(cors());
@@ -130,14 +135,6 @@ async function saveState(data: SetupData, shouldBeRunning = true): Promise<void>
   }, null, 2));
 }
 
-// Characters that would break the generated TOML basic string ("...").
-// eslint-disable-next-line no-control-regex
-const TOML_UNSAFE_CHARS = /["\\\u0000-\u001F\u007F]/;
-
-function isTomlSafeIdentifier(value: string): boolean {
-  return value !== '' && value === value.trim() && !TOML_UNSAFE_CHARS.test(value);
-}
-
 function configuredPools(data: SetupData): PoolConfig[] {
   if (data.miningMode === 'solo' && data.mode === 'jd') {
     return [];
@@ -149,18 +146,6 @@ function configuredPools(data: SetupData): PoolConfig[] {
   ].filter((pool): pool is PoolConfig => Boolean(pool));
 }
 
-function getPoolConfigError(pool: PoolConfig, label: string): string | null {
-  if (!pool.address) return `${label} address is required`;
-  if (!Number.isInteger(pool.port) || pool.port <= 0 || pool.port > 65535) {
-    return `${label} port must be between 1 and 65535`;
-  }
-  if (!pool.authority_public_key) return `${label} authority public key is required`;
-  if (!isTomlSafeIdentifier(pool.user_identity)) {
-    return `${label} username is required and cannot contain quotes, backslashes, or control characters`;
-  }
-  return null;
-}
-
 function getSetupValidationError(data: SetupData): string | null {
   const requiresPool = !(data.miningMode === 'solo' && data.mode === 'jd');
 
@@ -170,6 +155,10 @@ function getSetupValidationError(data: SetupData): string | null {
 
   if (data.mode === 'jd' && (!data.jdc || !data.bitcoin)) {
     return BITCOIN_ERROR_MESSAGES.jdConfig;
+  }
+
+  if ((data.fallbackPools?.length ?? 0) > MAX_FALLBACK_POOLS) {
+    return `No more than ${MAX_FALLBACK_POOLS} fallback pools may be configured`;
   }
 
   const pools = configuredPools(data);
@@ -345,6 +334,10 @@ app.put('/api/config', async (req, res) => {
   }
 
   try {
+    if (!isJsonObject(req.body)) {
+      return res.status(400).json({ success: false, error: 'Configuration update must be a JSON object' });
+    }
+
     const state = await loadState();
 
     if (!state.configured || !state.data) {
@@ -497,7 +490,11 @@ app.post('/api/setup', async (req, res) => {
   }
 
   try {
-    const data = normalizeSetupData(req.body as SetupData);
+    if (!isJsonObject(req.body)) {
+      return res.status(400).json({ success: false, error: 'Setup configuration must be a JSON object' });
+    }
+
+    const data = normalizeSetupData(req.body as unknown as SetupData);
 
     // Validate required fields
     const setupValidationError = getSetupValidationError(data);

--- a/server/src/pool-validation.test.ts
+++ b/server/src/pool-validation.test.ts
@@ -15,6 +15,15 @@ test('accepts a complete pool configuration', () => {
   assert.equal(getPoolConfigError(VALID_POOL, 'Primary pool'), null);
 });
 
+test('rejects empty and oversized pool names', () => {
+  for (const name of ['', 'a'.repeat(129)]) {
+    assert.match(
+      getPoolConfigError({ ...VALID_POOL, name }, 'Primary pool') ?? '',
+      /name is required/i,
+    );
+  }
+});
+
 test('rejects TOML-breaking pool addresses', () => {
   for (const address of ['pool.example.com"\nverify_payout = false', 'pool.example.com\\evil', 'pool.example.com\n']) {
     assert.match(

--- a/server/src/pool-validation.test.ts
+++ b/server/src/pool-validation.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { PoolConfig } from './types.js';
+import { getPoolConfigError } from './pool-validation.js';
+
+const VALID_POOL: PoolConfig = {
+  name: 'Custom Pool',
+  address: 'pool.example.com',
+  port: 3333,
+  authority_public_key: '9awtMD5KQgvRUh2yFbjVeT7b6hjipWcAsQHd6wEhgtDT9soosna',
+  user_identity: 'miner.worker1',
+};
+
+test('accepts a complete pool configuration', () => {
+  assert.equal(getPoolConfigError(VALID_POOL, 'Primary pool'), null);
+});
+
+test('rejects TOML-breaking pool addresses', () => {
+  for (const address of ['pool.example.com"\nverify_payout = false', 'pool.example.com\\evil', 'pool.example.com\n']) {
+    assert.match(
+      getPoolConfigError({ ...VALID_POOL, address }, 'Primary pool') ?? '',
+      /address/i,
+    );
+  }
+});
+
+test('rejects invalid and corrupted authority public keys', () => {
+  assert.match(
+    getPoolConfigError({ ...VALID_POOL, authority_public_key: 'not-a-key' }, 'Primary pool') ?? '',
+    /public key is invalid/i,
+  );
+  assert.match(
+    getPoolConfigError({
+      ...VALID_POOL,
+      authority_public_key: `${VALID_POOL.authority_public_key.slice(0, -1)}b`,
+    }, 'Primary pool') ?? '',
+    /public key is invalid/i,
+  );
+});
+
+test('rejects invalid ports and oversized identities', () => {
+  assert.match(
+    getPoolConfigError({ ...VALID_POOL, port: 65536 }, 'Primary pool') ?? '',
+    /port must be between/i,
+  );
+  assert.match(
+    getPoolConfigError({ ...VALID_POOL, user_identity: 'a'.repeat(513) }, 'Primary pool') ?? '',
+    /username/i,
+  );
+});

--- a/server/src/pool-validation.ts
+++ b/server/src/pool-validation.ts
@@ -1,0 +1,50 @@
+import bs58check from 'bs58check';
+import type { PoolConfig } from './types.js';
+
+const MAX_POOL_NAME_LENGTH = 128;
+const MAX_POOL_ADDRESS_LENGTH = 255;
+const MAX_AUTHORITY_KEY_LENGTH = 128;
+const MAX_IDENTITY_LENGTH = 512;
+export const MAX_FALLBACK_POOLS = 16;
+
+// These characters can escape or terminate a generated TOML basic string.
+// eslint-disable-next-line no-control-regex
+const TOML_UNSAFE_CHARS = /["\\\u0000-\u001F\u007F]/;
+
+function isSafeBoundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    value === value.trim() &&
+    !TOML_UNSAFE_CHARS.test(value);
+}
+
+function isValidAuthorityPublicKey(value: unknown): value is string {
+  if (!isSafeBoundedString(value, MAX_AUTHORITY_KEY_LENGTH)) return false;
+
+  try {
+    bs58check.decode(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getPoolConfigError(pool: PoolConfig, label: string): string | null {
+  if (typeof pool.name !== 'string' || pool.name.length > MAX_POOL_NAME_LENGTH) {
+    return `${label} name must be at most ${MAX_POOL_NAME_LENGTH} characters`;
+  }
+  if (!isSafeBoundedString(pool.address, MAX_POOL_ADDRESS_LENGTH)) {
+    return `${label} address is required and cannot contain quotes, backslashes, control characters, or surrounding whitespace`;
+  }
+  if (!Number.isInteger(pool.port) || pool.port <= 0 || pool.port > 65535) {
+    return `${label} port must be between 1 and 65535`;
+  }
+  if (!isValidAuthorityPublicKey(pool.authority_public_key)) {
+    return `${label} authority public key is invalid`;
+  }
+  if (!isSafeBoundedString(pool.user_identity, MAX_IDENTITY_LENGTH)) {
+    return `${label} username is required and cannot contain quotes, backslashes, control characters, or surrounding whitespace`;
+  }
+  return null;
+}

--- a/server/src/pool-validation.ts
+++ b/server/src/pool-validation.ts
@@ -31,8 +31,8 @@ function isValidAuthorityPublicKey(value: unknown): value is string {
 }
 
 export function getPoolConfigError(pool: PoolConfig, label: string): string | null {
-  if (typeof pool.name !== 'string' || pool.name.length > MAX_POOL_NAME_LENGTH) {
-    return `${label} name must be at most ${MAX_POOL_NAME_LENGTH} characters`;
+  if (typeof pool.name !== 'string' || pool.name.length === 0 || pool.name.length > MAX_POOL_NAME_LENGTH) {
+    return `${label} name is required and must be at most ${MAX_POOL_NAME_LENGTH} characters`;
   }
   if (!isSafeBoundedString(pool.address, MAX_POOL_ADDRESS_LENGTH)) {
     return `${label} address is required and cannot contain quotes, backslashes, control characters, or surrounding whitespace`;

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -293,7 +293,7 @@ export function Shell({
       </header>
 
       {/* Content */}
-      <main className="flex-1 overflow-auto">
+      <main className="min-h-0 flex-1 overflow-auto">
         <div className="px-4 sm:px-6 py-6 sm:py-8 mx-auto max-w-7xl space-y-6 sm:space-y-8 animate-fade-in">
           {children}
         </div>

--- a/src/components/pools/FallbackIdentitySection.tsx
+++ b/src/components/pools/FallbackIdentitySection.tsx
@@ -1,0 +1,140 @@
+import type { BitcoinNetwork, MiningMode, PoolConfig } from '@sv2-ui/shared';
+import { PoolIcon } from '@/components/ui/pool-icon';
+import { isSamePool, type KnownPool } from '@/lib/pools';
+import {
+  getCompatiblePoolIdentity,
+  withCompatiblePoolIdentity,
+} from '@/lib/miningIdentity';
+import { PoolIdentityFields } from './PoolIdentityFields';
+
+interface FallbackIdentitySectionProps {
+  primaryPool: PoolConfig;
+  fallbackPools: PoolConfig[];
+  presets: KnownPool[];
+  miningMode: MiningMode | null;
+  network: BitcoinNetwork;
+  identityLabel: string;
+  idPrefix: string;
+  expanded: boolean;
+  hasBlockingError: boolean;
+  onToggle: () => void;
+  onChange: (index: number, pool: PoolConfig) => void;
+}
+
+function getSelectedPreset(pool: PoolConfig, presets: KnownPool[]): KnownPool | null {
+  return presets.find((preset) => isSamePool(pool, preset)) ?? null;
+}
+
+export function FallbackIdentitySection({
+  primaryPool,
+  fallbackPools,
+  presets,
+  miningMode,
+  network,
+  identityLabel,
+  idPrefix,
+  expanded,
+  hasBlockingError,
+  onToggle,
+  onChange,
+}: FallbackIdentitySectionProps) {
+  const customizedCount = fallbackPools.filter((pool) => (
+    pool.user_identity !== getCompatiblePoolIdentity(primaryPool, pool, miningMode)
+  )).length;
+  const normalizedLabel = identityLabel.toLowerCase();
+
+  if (!expanded) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <span>
+            {customizedCount === 0
+              ? `Fallback pools use the primary ${normalizedLabel}.`
+              : `${customizedCount} fallback ${customizedCount === 1 ? 'pool uses' : 'pools use'} a custom ${normalizedLabel}.`}
+          </span>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="self-start rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:self-auto"
+          >
+            {customizedCount === 0 ? 'Customize' : 'Review'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-4 rounded-lg border p-4 ${
+      hasBlockingError
+        ? 'border-destructive/40 bg-destructive/[0.08]'
+        : 'border-border bg-muted/20'
+    }`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold">Fallback identities</h3>
+          <p className={`mt-1 text-sm ${hasBlockingError ? 'text-destructive' : 'text-muted-foreground'}`}>
+            {hasBlockingError
+              ? `Set a valid fallback ${normalizedLabel} or remove the fallback pool.`
+              : `Optional. Fallbacks inherit the primary ${normalizedLabel} unless overridden here.`}
+          </p>
+        </div>
+        {!hasBlockingError && (
+          <button
+            type="button"
+            onClick={onToggle}
+            className="self-start rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:self-auto"
+          >
+            Hide
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        {fallbackPools.map((pool, index) => {
+          const selectedPreset = getSelectedPreset(pool, presets);
+          const displayName = selectedPreset?.name ?? pool.name ?? `Fallback ${index + 1}`;
+
+          return (
+            <div key={`${idPrefix}-${index}`} className="rounded-lg border border-border bg-card p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <PoolIcon
+                    logoUrl={selectedPreset?.logoUrl}
+                    logoOnDark={selectedPreset?.logoOnDark}
+                    monogram={selectedPreset?.monogram}
+                    name={displayName}
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{displayName}</div>
+                    <div className="truncate font-mono text-xs text-muted-foreground">
+                      {pool.address}:{pool.port}
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onChange(
+                    index,
+                    withCompatiblePoolIdentity(primaryPool, pool, miningMode),
+                  )}
+                  className="shrink-0 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
+                  Use primary
+                </button>
+              </div>
+
+              <PoolIdentityFields
+                pool={pool}
+                miningMode={miningMode}
+                network={network}
+                idPrefix={`${idPrefix}-${index}`}
+                onChange={(nextPool) => onChange(index, nextPool)}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pools/FallbackIdentitySection.tsx
+++ b/src/components/pools/FallbackIdentitySection.tsx
@@ -99,6 +99,8 @@ export function FallbackIdentitySection({
                   logoUrl={selectedPreset?.logoUrl}
                   logoOnDark={selectedPreset?.logoOnDark}
                   monogram={selectedPreset?.monogram}
+                  invertLogoInDarkMode={selectedPreset?.invertLogoInDarkMode}
+                  logoScale={selectedPreset?.logoScale}
                   name={displayName}
                 />
                 <div className="min-w-0">

--- a/src/components/pools/FallbackIdentitySection.tsx
+++ b/src/components/pools/FallbackIdentitySection.tsx
@@ -1,10 +1,7 @@
 import type { BitcoinNetwork, MiningMode, PoolConfig } from '@sv2-ui/shared';
 import { PoolIcon } from '@/components/ui/pool-icon';
 import { isSamePool, type KnownPool } from '@/lib/pools';
-import {
-  getCompatiblePoolIdentity,
-  withCompatiblePoolIdentity,
-} from '@/lib/miningIdentity';
+import { getCompatiblePoolIdentity } from '@/lib/miningIdentity';
 import { PoolIdentityFields } from './PoolIdentityFields';
 
 interface FallbackIdentitySectionProps {
@@ -97,31 +94,19 @@ export function FallbackIdentitySection({
 
           return (
             <div key={`${idPrefix}-${index}`} className="rounded-lg border border-border bg-card p-4">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-3">
-                  <PoolIcon
-                    logoUrl={selectedPreset?.logoUrl}
-                    logoOnDark={selectedPreset?.logoOnDark}
-                    monogram={selectedPreset?.monogram}
-                    name={displayName}
-                  />
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{displayName}</div>
-                    <div className="truncate font-mono text-xs text-muted-foreground">
-                      {pool.address}:{pool.port}
-                    </div>
+              <div className="mb-3 flex min-w-0 items-center gap-3">
+                <PoolIcon
+                  logoUrl={selectedPreset?.logoUrl}
+                  logoOnDark={selectedPreset?.logoOnDark}
+                  monogram={selectedPreset?.monogram}
+                  name={displayName}
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{displayName}</div>
+                  <div className="truncate font-mono text-xs text-muted-foreground">
+                    {pool.address}:{pool.port}
                   </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => onChange(
-                    index,
-                    withCompatiblePoolIdentity(primaryPool, pool, miningMode),
-                  )}
-                  className="shrink-0 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                >
-                  Use primary
-                </button>
               </div>
 
               <PoolIdentityFields

--- a/src/components/pools/PoolIdentityFields.tsx
+++ b/src/components/pools/PoolIdentityFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AlertCircle } from 'lucide-react';
 import {
   shouldAggregateTranslatorChannels,
@@ -104,17 +104,25 @@ function SriPoolIdentityFields({
   onChange: (pool: PoolConfig) => void;
 }) {
   const parsed = parseSriIdentity(pool.user_identity);
+  const [savedPayoutAddress, setSavedPayoutAddress] = useState(parsed.address);
+  const payoutAddress = parsed.address || savedPayoutAddress;
   const needsAddress = parsed.donationPercent < 100;
   const identityError = getPoolIdentityError(pool, 'solo', network);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
   useEffect(() => {
     const normalizedPool = normalizePoolUserIdentity(pool, 'solo');
     if (normalizedPool !== pool) {
-      onChange(normalizedPool);
+      onChangeRef.current(normalizedPool);
     }
-  }, [onChange, pool]);
+  }, [pool]);
 
   const updateSriIdentity = (address: string, workerName: string, donationPercent: number) => {
+    setSavedPayoutAddress(address);
     onChange({
       ...pool,
       user_identity: buildSriIdentity(address, workerName, donationPercent),
@@ -132,15 +140,15 @@ function SriPoolIdentityFields({
           <input
             id={`${idPrefix}-payout-address`}
             type="text"
-            value={parsed.address}
+            value={payoutAddress}
             onChange={(event) => updateSriIdentity(event.target.value, parsed.workerName, parsed.donationPercent)}
             placeholder={getBitcoinAddressPlaceholder(network)}
             aria-required="true"
             autoComplete="off"
             className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
           />
-          {getBitcoinAddressError(parsed.address, network) && (
-            <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(parsed.address, network)}</p>
+          {getBitcoinAddressError(payoutAddress, network) && (
+            <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(payoutAddress, network)}</p>
           )}
           <p className="text-xs text-muted-foreground mt-2">
             Used with worker and donation settings to build this pool identity.
@@ -156,7 +164,7 @@ function SriPoolIdentityFields({
           id={`${idPrefix}-worker-name`}
           type="text"
           value={parsed.workerName}
-          onChange={(event) => updateSriIdentity(parsed.address, event.target.value, parsed.donationPercent)}
+          onChange={(event) => updateSriIdentity(payoutAddress, event.target.value, parsed.donationPercent)}
           placeholder="worker1"
           autoComplete="off"
           className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
@@ -175,7 +183,7 @@ function SriPoolIdentityFields({
             max={100}
             value={parsed.donationPercent}
             onChange={(event) => updateSriIdentity(
-              parsed.address,
+              payoutAddress,
               parsed.workerName,
               snapDonation(Number(event.target.value)),
             )}

--- a/src/components/pools/PoolIdentityFields.tsx
+++ b/src/components/pools/PoolIdentityFields.tsx
@@ -1,0 +1,213 @@
+import { useEffect } from 'react';
+import { AlertCircle } from 'lucide-react';
+import {
+  shouldAggregateTranslatorChannels,
+  type BitcoinNetwork,
+  type MiningMode,
+  type PoolConfig,
+} from '@sv2-ui/shared';
+import {
+  buildSriIdentity,
+  getPoolIdentityError,
+  isSriPool,
+  normalizePoolUserIdentity,
+  parseSriIdentity,
+} from '@/lib/miningIdentity';
+import {
+  getBitcoinAddressError,
+  getBitcoinAddressPlaceholder,
+} from '@/lib/utils';
+
+const DONATION_SNAP_POINTS = [0, 10, 25, 50, 75, 100];
+const DONATION_SNAP_THRESHOLD = 3;
+
+function snapDonation(value: number): number {
+  const nearest = DONATION_SNAP_POINTS.find((point) => (
+    Math.abs(value - point) <= DONATION_SNAP_THRESHOLD
+  ));
+  return nearest ?? value;
+}
+
+export function PoolIdentityFields({
+  pool,
+  miningMode,
+  network,
+  idPrefix,
+  onChange,
+}: {
+  pool: PoolConfig;
+  miningMode: MiningMode | null;
+  network: BitcoinNetwork;
+  idPrefix: string;
+  onChange: (pool: PoolConfig) => void;
+}) {
+  if (miningMode === 'solo' && isSriPool(pool)) {
+    return (
+      <SriPoolIdentityFields
+        pool={pool}
+        network={network}
+        idPrefix={idPrefix}
+        onChange={onChange}
+      />
+    );
+  }
+
+  const label = miningMode === 'solo' ? 'Payout address' : 'Pool username';
+  const placeholder = miningMode === 'solo' ? getBitcoinAddressPlaceholder(network) : 'username.worker1';
+  const error = getPoolIdentityError(pool, miningMode, network);
+  const showBraiinsUsernameWarning = miningMode !== 'solo' && shouldAggregateTranslatorChannels(pool);
+
+  return (
+    <div>
+      <label htmlFor={`${idPrefix}-identity`} className="block text-sm font-medium mb-2">
+        {label} <span className="text-primary" aria-hidden="true">*</span>
+        <span className="sr-only">(required)</span>
+      </label>
+      {showBraiinsUsernameWarning && (
+        <div className="mb-3 flex gap-3 rounded-xl bg-warning/[0.08] p-4 text-sm text-warning" role="alert">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <p>
+            Use the exact username from your Braiins Pool account. If this value does not match an existing
+            Braiins account, the pool connection will not be established properly.
+          </p>
+        </div>
+      )}
+      <input
+        id={`${idPrefix}-identity`}
+        type="text"
+        value={pool.user_identity}
+        onChange={(event) => onChange({ ...pool, user_identity: event.target.value })}
+        placeholder={placeholder}
+        aria-required="true"
+        autoComplete="off"
+        className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
+      />
+      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+      <p className="text-xs text-muted-foreground mt-2">
+        {miningMode === 'solo'
+          ? 'Bitcoin address used by the pool for solo mining payouts.'
+          : 'Pool account username sent to this upstream'}
+      </p>
+    </div>
+  );
+}
+
+function SriPoolIdentityFields({
+  pool,
+  network,
+  idPrefix,
+  onChange,
+}: {
+  pool: PoolConfig;
+  network: BitcoinNetwork;
+  idPrefix: string;
+  onChange: (pool: PoolConfig) => void;
+}) {
+  const parsed = parseSriIdentity(pool.user_identity);
+  const needsAddress = parsed.donationPercent < 100;
+  const identityError = getPoolIdentityError(pool, 'solo', network);
+
+  useEffect(() => {
+    const normalizedPool = normalizePoolUserIdentity(pool, 'solo');
+    if (normalizedPool !== pool) {
+      onChange(normalizedPool);
+    }
+  }, [onChange, pool]);
+
+  const updateSriIdentity = (address: string, workerName: string, donationPercent: number) => {
+    onChange({
+      ...pool,
+      user_identity: buildSriIdentity(address, workerName, donationPercent),
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {needsAddress && (
+        <div>
+          <label htmlFor={`${idPrefix}-payout-address`} className="block text-sm font-medium mb-2">
+            Bitcoin payout address <span className="text-primary" aria-hidden="true">*</span>
+            <span className="sr-only">(required)</span>
+          </label>
+          <input
+            id={`${idPrefix}-payout-address`}
+            type="text"
+            value={parsed.address}
+            onChange={(event) => updateSriIdentity(event.target.value, parsed.workerName, parsed.donationPercent)}
+            placeholder={getBitcoinAddressPlaceholder(network)}
+            aria-required="true"
+            autoComplete="off"
+            className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
+          />
+          {getBitcoinAddressError(parsed.address, network) && (
+            <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(parsed.address, network)}</p>
+          )}
+          <p className="text-xs text-muted-foreground mt-2">
+            Used with worker and donation settings to build this pool identity.
+          </p>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor={`${idPrefix}-worker-name`} className="block text-sm font-medium mb-2">
+          Worker Name <span className="text-muted-foreground text-xs font-normal">(optional)</span>
+        </label>
+        <input
+          id={`${idPrefix}-worker-name`}
+          type="text"
+          value={parsed.workerName}
+          onChange={(event) => updateSriIdentity(parsed.address, event.target.value, parsed.donationPercent)}
+          placeholder="worker1"
+          autoComplete="off"
+          className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
+        />
+      </div>
+
+      <div>
+        <label htmlFor={`${idPrefix}-donation-slider`} className="block text-sm font-medium mb-2">
+          Donation to SRI Development <span className="text-muted-foreground text-xs font-normal">(optional)</span>
+        </label>
+        <div className="p-4 rounded-xl bg-muted/40 space-y-3">
+          <input
+            id={`${idPrefix}-donation-slider`}
+            type="range"
+            min={0}
+            max={100}
+            value={parsed.donationPercent}
+            onChange={(event) => updateSriIdentity(
+              parsed.address,
+              parsed.workerName,
+              snapDonation(Number(event.target.value)),
+            )}
+            aria-label={`Donation: ${parsed.donationPercent}%`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={parsed.donationPercent}
+            className="w-full accent-primary"
+            list={`${idPrefix}-donation-snap-points`}
+          />
+          <datalist id={`${idPrefix}-donation-snap-points`}>
+            <option value="0" />
+            <option value="10" />
+            <option value="25" />
+            <option value="50" />
+            <option value="75" />
+            <option value="100" />
+          </datalist>
+          <div className="flex justify-between text-xs text-muted-foreground select-none">
+            <span>0%</span><span>25%</span><span>50%</span><span>75%</span><span>100%</span>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground mt-2">
+          {parsed.donationPercent === 0
+            ? 'Full block reward goes to your payout address'
+            : parsed.donationPercent >= 100
+              ? 'Full block reward is donated to SRI development'
+              : `${parsed.donationPercent}% of the block reward goes to SRI development, ${100 - parsed.donationPercent}% to your address`}
+        </p>
+      </div>
+
+      {identityError && <p className="text-xs text-destructive">{identityError}</p>}
+    </div>
+  );
+}

--- a/src/components/pools/PoolPriorityEditor.tsx
+++ b/src/components/pools/PoolPriorityEditor.tsx
@@ -150,7 +150,14 @@ export function PoolPriorityEditor({
               </button>
 
               <div className="flex min-w-0 items-center gap-4">
-                <PoolIcon logoUrl={preset?.logoUrl} logoOnDark={preset?.logoOnDark} monogram={preset?.monogram} name={displayName} />
+                <PoolIcon
+                  logoUrl={preset?.logoUrl}
+                  logoOnDark={preset?.logoOnDark}
+                  monogram={preset?.monogram}
+                  invertLogoInDarkMode={preset?.invertLogoInDarkMode}
+                  logoScale={preset?.logoScale}
+                  name={displayName}
+                />
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="truncate text-sm font-medium text-primary">{displayName}</span>
@@ -237,7 +244,14 @@ export function PoolPriorityEditor({
               </div>
             )}
             <div className="flex items-start gap-4">
-              <PoolIcon logoUrl={preset.logoUrl} logoOnDark={preset.logoOnDark} monogram={preset.monogram} name={preset.name} />
+              <PoolIcon
+                logoUrl={preset.logoUrl}
+                logoOnDark={preset.logoOnDark}
+                monogram={preset.monogram}
+                invertLogoInDarkMode={preset.invertLogoInDarkMode}
+                logoScale={preset.logoScale}
+                name={preset.name}
+              />
               <div className="flex-1 min-w-0 pr-8">
                 <div className="font-medium text-sm mb-1">{preset.name}</div>
                 {preset.address && (

--- a/src/components/pools/PoolPriorityEditor.tsx
+++ b/src/components/pools/PoolPriorityEditor.tsx
@@ -1,0 +1,344 @@
+import { useRef, useState } from 'react';
+import { ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
+import { DEFAULT_POOL_PORT, type MiningMode, type PoolConfig } from '@sv2-ui/shared';
+import { PoolIcon } from '@/components/ui/pool-icon';
+import {
+  createEmptyCustomPool,
+  isSamePool,
+  knownPoolToConfig,
+  type KnownPool,
+} from '@/lib/pools';
+import { withCompatiblePoolIdentity } from '@/lib/miningIdentity';
+import { getPoolAuthorityPubkeyError, stripWrappingQuotes } from '@/lib/utils';
+
+interface PoolPriorityEditorProps {
+  presets: KnownPool[];
+  pools: PoolConfig[];
+  miningMode: MiningMode | null;
+  onChange: (pools: PoolConfig[]) => void;
+}
+
+function getSelectedPreset(pool: PoolConfig, presets: KnownPool[]): KnownPool | null {
+  return presets.find((preset) => isSamePool(pool, preset)) ?? null;
+}
+
+export function PoolPriorityEditor({
+  presets,
+  pools,
+  miningMode,
+  onChange,
+}: PoolPriorityEditorProps) {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const draggedIndexRef = useRef<number | null>(null);
+  const selectedCustomIndex = pools.findIndex((pool) => !getSelectedPreset(pool, presets));
+  const unselectedPresets = presets.filter((preset) => (
+    !pools.some((selectedPool) => isSamePool(selectedPool, preset))
+  ));
+
+  const togglePreset = (preset: KnownPool) => {
+    const selectedIndex = pools.findIndex((pool) => isSamePool(pool, preset));
+    if (selectedIndex >= 0) {
+      onChange(pools.filter((_, index) => index !== selectedIndex));
+      return;
+    }
+
+    if (preset.badge === 'coming-soon') return;
+
+    onChange([
+      ...pools,
+      withCompatiblePoolIdentity(
+        pools[0],
+        knownPoolToConfig(preset),
+        miningMode,
+      ),
+    ]);
+  };
+
+  const toggleCustomPool = () => {
+    if (selectedCustomIndex >= 0) {
+      onChange(pools.filter((_, index) => index !== selectedCustomIndex));
+      return;
+    }
+
+    onChange([
+      ...pools,
+      withCompatiblePoolIdentity(
+        pools[0],
+        createEmptyCustomPool(),
+        miningMode,
+      ),
+    ]);
+  };
+
+  const updatePool = (index: number, pool: PoolConfig) => {
+    onChange(pools.map((item, itemIndex) => itemIndex === index ? pool : item));
+  };
+
+  const removePool = (index: number) => {
+    onChange(pools.filter((_, itemIndex) => itemIndex !== index));
+  };
+
+  const movePool = (fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex || toIndex < 0 || toIndex >= pools.length) return;
+
+    const nextPools = [...pools];
+    const [movedPool] = nextPools.splice(fromIndex, 1);
+    nextPools.splice(toIndex, 0, movedPool);
+    onChange(nextPools);
+  };
+
+  const finishDrag = (toIndex: number) => {
+    if (draggedIndexRef.current !== null) {
+      movePool(draggedIndexRef.current, toIndex);
+    }
+    draggedIndexRef.current = null;
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+
+  return (
+    <div className="space-y-2">
+      {pools.map((pool, index) => {
+        const preset = getSelectedPreset(pool, presets);
+        const isCustom = !preset;
+        const displayName = preset?.name ?? pool.name ?? 'Custom Pool';
+
+        return (
+          <div
+            key={`selected-pool-${index}`}
+            onDragEnter={() => {
+              if (draggedIndexRef.current !== null && draggedIndexRef.current !== index) {
+                setDragOverIndex(index);
+              }
+            }}
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = 'move';
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+              finishDrag(index);
+            }}
+            className={`rounded-xl border bg-card transition-colors ${
+              dragOverIndex === index && draggedIndex !== index
+                ? 'border-primary bg-primary/[0.04]'
+                : 'border-primary/70'
+            } ${draggedIndex === index ? 'opacity-60' : ''}`}
+          >
+            <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 p-4">
+              <button
+                type="button"
+                draggable
+                onDragStart={(event) => {
+                  draggedIndexRef.current = index;
+                  setDraggedIndex(index);
+                  setDragOverIndex(index);
+                  event.dataTransfer.effectAllowed = 'move';
+                  event.dataTransfer.setData('text/plain', String(index));
+                }}
+                onDragEnd={() => {
+                  draggedIndexRef.current = null;
+                  setDraggedIndex(null);
+                  setDragOverIndex(null);
+                }}
+                className="inline-flex h-11 w-9 cursor-grab items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                aria-label={`Drag ${displayName} to reorder pool priority`}
+                title="Drag to reorder priority"
+              >
+                <GripVertical className="h-5 w-5" aria-hidden="true" />
+              </button>
+
+              <div className="flex min-w-0 items-center gap-4">
+                <PoolIcon logoUrl={preset?.logoUrl} logoOnDark={preset?.logoOnDark} monogram={preset?.monogram} name={displayName} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-medium text-primary">{displayName}</span>
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                      {index === 0 ? 'Primary' : `Fallback ${index}`}
+                    </span>
+                  </div>
+                  {pool.address && (
+                    <div className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                      {pool.address}:{pool.port}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => movePool(index, index - 1)}
+                  disabled={index === 0}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  aria-label={`Move ${displayName} up`}
+                  title="Move up"
+                >
+                  <ArrowUp className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => movePool(index, index + 1)}
+                  disabled={index === pools.length - 1}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  aria-label={`Move ${displayName} down`}
+                  title="Move down"
+                >
+                  <ArrowDown className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removePool(index)}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  aria-label={`Remove ${displayName} from pool priority`}
+                  title="Remove"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+
+            {isCustom && (
+              <CustomPoolFields
+                pool={pool}
+                idPrefix={`custom-pool-${index}`}
+                onChange={(nextPool) => updatePool(index, nextPool)}
+              />
+            )}
+          </div>
+        );
+      })}
+
+      {unselectedPresets.map((preset) => {
+        const isDisabled = preset.badge === 'coming-soon';
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => togglePreset(preset)}
+            disabled={isDisabled}
+            aria-pressed="false"
+            className={`group w-full p-5 rounded-xl border transition-all text-left relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+              isDisabled
+                ? 'border-border opacity-50 cursor-not-allowed bg-card'
+                : 'border-border bg-card hover:border-primary/45 hover:bg-primary/[0.02]'
+            }`}
+          >
+            {preset.badge && (
+              <div className="absolute top-4 right-4">
+                <span className={`text-xs font-medium uppercase tracking-wider px-2 py-0.5 rounded-full ${
+                  preset.badge === 'testing'
+                    ? 'bg-warning/10 text-warning'
+                    : 'bg-muted text-muted-foreground'
+                }`}>
+                  {preset.badge === 'testing' ? 'Testing' : 'Coming Soon'}
+                </span>
+              </div>
+            )}
+            <div className="flex items-start gap-4">
+              <PoolIcon logoUrl={preset.logoUrl} logoOnDark={preset.logoOnDark} monogram={preset.monogram} name={preset.name} />
+              <div className="flex-1 min-w-0 pr-8">
+                <div className="font-medium text-sm mb-1">{preset.name}</div>
+                {preset.address && (
+                  <div className="text-xs text-muted-foreground font-mono">
+                    {preset.address}:{preset.port}
+                  </div>
+                )}
+              </div>
+            </div>
+          </button>
+        );
+      })}
+
+      {selectedCustomIndex === -1 && (
+        <button
+          type="button"
+          onClick={toggleCustomPool}
+          aria-pressed="false"
+          className="group w-full p-5 rounded-xl border border-border bg-card transition-all text-left relative hover:border-primary/45 hover:bg-primary/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <div className="pr-8">
+            <div className="font-medium text-sm">Custom Pool</div>
+          </div>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CustomPoolFields({
+  pool,
+  idPrefix,
+  onChange,
+}: {
+  pool: PoolConfig;
+  idPrefix: string;
+  onChange: (pool: PoolConfig) => void;
+}) {
+  const updateField = (field: keyof PoolConfig, value: string | number) => {
+    const normalized =
+      field === 'authority_public_key' && typeof value === 'string'
+        ? stripWrappingQuotes(value)
+        : value;
+    onChange({ ...pool, [field]: normalized });
+  };
+  const pubkeyError = getPoolAuthorityPubkeyError(pool.authority_public_key);
+
+  return (
+    <div className="border-t border-border bg-muted/20 p-3">
+      <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_7rem_minmax(0,1.4fr)]">
+        <div>
+          <label htmlFor={`${idPrefix}-address`} className="mb-1 block text-xs font-medium text-muted-foreground">
+            Address
+          </label>
+          <input
+            id={`${idPrefix}-address`}
+            type="text"
+            value={pool.address}
+            onChange={(event) => updateField('address', event.target.value)}
+            placeholder="pool.example.com"
+            aria-required="true"
+            autoComplete="off"
+            className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
+          />
+        </div>
+
+        <div>
+          <label htmlFor={`${idPrefix}-port`} className="mb-1 block text-xs font-medium text-muted-foreground">
+            Port
+          </label>
+          <input
+            id={`${idPrefix}-port`}
+            type="number"
+            min={1}
+            max={65535}
+            value={pool.port}
+            onChange={(event) => updateField('port', parseInt(event.target.value, 10) || DEFAULT_POOL_PORT)}
+            aria-required="true"
+            className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
+          />
+        </div>
+
+        <div>
+          <label htmlFor={`${idPrefix}-pubkey`} className="mb-1 block text-xs font-medium text-muted-foreground">
+            Authority Public Key
+          </label>
+          <input
+            id={`${idPrefix}-pubkey`}
+            type="text"
+            value={pool.authority_public_key}
+            onChange={(event) => updateField('authority_public_key', event.target.value)}
+            placeholder="Pool authority public key"
+            aria-required="true"
+            autoComplete="off"
+            className={`h-9 w-full rounded-lg border bg-background px-3 font-mono text-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-primary/15 ${
+              pubkeyError ? 'border-destructive focus-visible:border-destructive' : 'border-input focus-visible:border-primary'
+            }`}
+          />
+          {pubkeyError && <p className="mt-1 text-xs text-destructive">{pubkeyError}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type DragEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'wouter';
 import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -6,48 +6,36 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { PoolIcon } from '@/components/ui/pool-icon';
+import { FallbackIdentitySection } from '@/components/pools/FallbackIdentitySection';
+import { PoolIdentityFields } from '@/components/pools/PoolIdentityFields';
+import { PoolPriorityEditor } from '@/components/pools/PoolPriorityEditor';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
 import {
-  createEmptyCustomPool,
   getKnownPoolForConfig,
   getPoolsForMode,
-  isSamePool,
-  knownPoolToConfig,
-  type KnownPool,
 } from '@/lib/pools';
 import {
-  buildSriIdentity,
   getPoolIdentityError,
   getPoolUserIdentityDisplay,
-  isSriPool,
-  normalizePoolUserIdentity,
-  parseSriIdentity,
+  normalizePoolPriorityIdentities,
 } from '@/lib/miningIdentity';
 import {
-  getBitcoinAddressError,
-  getBitcoinAddressPlaceholder,
   getIdentifierError,
-  getPoolAuthorityPubkeyError,
-  isValidPoolAuthorityPubkey,
   isTomlSafeIdentifier,
-  stripWrappingQuotes,
 } from '@/lib/utils';
+import { isPoolComplete } from '@/lib/poolValidation';
 import { isBitcoinSocketError } from '@/lib/bitcoinSocketErrors';
 import type { PoolConfig, SetupData } from '@/components/setup/types';
 import {
   DEFAULT_SHARES_PER_MINUTE,
   DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE,
-  DEFAULT_POOL_PORT,
   formatBitcoinCoreVersion,
   normalizeBitcoinCoreVersion,
 } from '@sv2-ui/shared';
 import {
   Loader2,
   AlertCircle,
-  ArrowDown,
-  ArrowUp,
-  GripVertical,
   RotateCw,
   StopCircle,
   Trash2,
@@ -81,15 +69,8 @@ function clearPersistedDashboardState() {
 }
 
 const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
-const DONATION_SNAP_POINTS = [0, 10, 25, 50, 75, 100];
-const DONATION_SNAP_THRESHOLD = 3;
 
-type EditingField = null | 'pool' | 'fallbackPools' | 'mode' | 'signature' | 'advanced';
-
-function snapDonation(value: number): number {
-  const nearest = DONATION_SNAP_POINTS.find((p) => Math.abs(value - p) <= DONATION_SNAP_THRESHOLD);
-  return nearest ?? value;
-}
+type EditingField = null | 'pools' | 'mode' | 'signature' | 'advanced';
 
 function isPositiveNumber(value: string): boolean {
   const parsed = Number(value);
@@ -130,9 +111,8 @@ export function ConfigurationTab() {
   } = useControlApi();
 
   const [editing, setEditing] = useState<EditingField>(null);
-  const [editPool, setEditPool] = useState<PoolConfig | null>(null);
-  const [editFallbackPools, setEditFallbackPools] = useState<PoolConfig[] | null>(null);
-  const [isCustomPool, setIsCustomPool] = useState(false);
+  const [editPools, setEditPools] = useState<PoolConfig[] | null>(null);
+  const [showFallbackIdentityFields, setShowFallbackIdentityFields] = useState(false);
   const [editMode, setEditMode] = useState<'jd' | 'no-jd' | null>(null);
   const [editSignature, setEditSignature] = useState<string>('');
   const [editAdvanced, setEditAdvanced] = useState<{
@@ -211,20 +191,16 @@ export function ConfigurationTab() {
     navigate('/setup');
   };
 
-  const startEditPool = () => {
+  const startEditPools = () => {
     if (!config?.pool) return;
-    const availablePools = getPoolsForMode(config.miningMode, config.mode);
-    const matchesPreset = availablePools.some(p => p.address === config.pool?.address && p.port === config.pool?.port);
-    setIsCustomPool(!matchesPreset);
-    setEditPool(normalizePoolUserIdentity({ ...config.pool }, config.miningMode));
-    setEditing('pool');
-  };
-
-  const startEditFallbackPools = () => {
-    setEditFallbackPools((config?.fallbackPools ?? []).map((pool) => (
-      normalizePoolUserIdentity(pool, config?.miningMode ?? null)
-    )));
-    setEditing('fallbackPools');
+    const configuredPools = [config.pool, ...(config.fallbackPools ?? [])];
+    setEditPools(normalizePoolPriorityIdentities(
+      configuredPools,
+      config.pool,
+      config.miningMode,
+    ));
+    setShowFallbackIdentityFields(false);
+    setEditing('pools');
   };
 
   const startEditMode = () => {
@@ -252,32 +228,19 @@ export function ConfigurationTab() {
 
   const cancelEdit = () => {
     setEditing(null);
-    setEditPool(null);
-    setEditFallbackPools(null);
-    setIsCustomPool(false);
+    setEditPools(null);
+    setShowFallbackIdentityFields(false);
     setEditMode(null);
     setEditSignature('');
     setEditAdvanced(null);
   };
 
   const editNetwork = config?.bitcoin?.network ?? 'mainnet';
-  const isPoolValid =
-    !!editPool?.address &&
-    Number.isInteger(editPool.port) &&
-    editPool.port > 0 &&
-    editPool.port <= 65535 &&
-    !!editPool?.authority_public_key &&
-    isValidPoolAuthorityPubkey(editPool.authority_public_key) &&
-    !getPoolIdentityError(editPool, config?.miningMode ?? null, editNetwork);
-  const isFallbackPoolsValid = (editFallbackPools ?? []).every((pool) => (
-    !!pool.address &&
-    Number.isInteger(pool.port) &&
-    pool.port > 0 &&
-    pool.port <= 65535 &&
-    !!pool.authority_public_key &&
-    isValidPoolAuthorityPubkey(pool.authority_public_key) &&
-    !getPoolIdentityError(pool, config?.miningMode ?? null, editNetwork)
-  ));
+  const arePoolsValid =
+    (editPools?.length ?? 0) > 0 &&
+    (editPools ?? []).every((pool) => (
+      isPoolComplete(pool, config?.miningMode ?? null, editNetwork)
+    ));
   const isSignatureValid = editSignature === '' || isTomlSafeIdentifier(editSignature);
   const isAdvancedValid =
     !!editAdvanced &&
@@ -289,12 +252,10 @@ export function ConfigurationTab() {
 
     const updated: SetupData = { ...config };
 
-    if (editing === 'pool' && editPool) {
-      if (!isPoolValid) return;
-      updated.pool = { ...editPool };
-    } else if (editing === 'fallbackPools') {
-      if (!isFallbackPoolsValid || !editFallbackPools) return;
-      updated.fallbackPools = [...editFallbackPools];
+    if (editing === 'pools') {
+      if (!arePoolsValid || !editPools) return;
+      updated.pool = editPools[0] ?? null;
+      updated.fallbackPools = editPools.slice(1);
     } else if (editing === 'mode') {
       if (editMode === 'jd' && !config.bitcoin) {
         navigate('/setup');
@@ -399,6 +360,25 @@ export function ConfigurationTab() {
       : 'Pool Templates';
   const pools = getPoolsForMode(activeMiningMode, activeMode);
   const isSaving = isSettingUp;
+  const editPrimaryPool = editPools?.[0] ?? null;
+  const editFallbackPools = editPools?.slice(1) ?? [];
+  const identityLabel = activeMiningMode === 'solo' ? 'Payout address' : 'Pool username';
+  const primaryIdentityValid = editPrimaryPool
+    ? !getPoolIdentityError(editPrimaryPool, activeMiningMode, editNetwork)
+    : false;
+  const fallbackIdentityBlocked = primaryIdentityValid && editFallbackPools.some((pool) => (
+    Boolean(getPoolIdentityError(pool, activeMiningMode, editNetwork))
+  ));
+
+  const updateEditPoolIdentity = (index: number, nextPool: PoolConfig) => {
+    setEditPools((currentPools) => currentPools
+      ? normalizePoolPriorityIdentities(
+          currentPools.map((pool, poolIndex) => poolIndex === index ? nextPool : pool),
+          currentPools[0],
+          activeMiningMode,
+        )
+      : null);
+  };
 
   return (
     <div className="space-y-6 animate-in slide-in-from-left-2 duration-300">
@@ -587,158 +567,102 @@ export function ConfigurationTab() {
             </div>
           )}
 
-          {/* Pool — inline-editable when not Sovereign Solo */}
+          {/* Pool priority — shared with Setup */}
           {!isSovereignSolo && config.pool && (
             <ConfigRow
-              label="Pool"
-              editing={editing === 'pool'}
-              onEdit={startEditPool}
+              label="Pools"
+              editing={editing === 'pools'}
+              onEdit={startEditPools}
               onSave={saveEdit}
               onCancel={cancelEdit}
               isSaving={isSaving}
-              saveDisabled={!isPoolValid}
-              disabled={editing !== null && editing !== 'pool'}
+              saveDisabled={!arePoolsValid}
+              disabled={editing !== null && editing !== 'pools'}
               display={
-                <PoolSummary
-                  pool={config.pool}
-                  miningMode={activeMiningMode}
-                  isActive={isRunning && activePoolIndex === 0}
-                />
+                <div className="space-y-3">
+                  <div>
+                    <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Primary
+                    </p>
+                    <PoolSummary
+                      pool={config.pool}
+                      miningMode={activeMiningMode}
+                      isActive={isRunning && activePoolIndex === 0}
+                    />
+                  </div>
+                  {(config.fallbackPools ?? []).length > 0 && (
+                    <div className="space-y-2 border-t border-border/60 pt-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Fallback priority
+                      </p>
+                      {config.fallbackPools.map((pool, index) => (
+                        <PoolSummary
+                          key={`${pool.address}:${pool.port}:${index}`}
+                          pool={pool}
+                          miningMode={activeMiningMode}
+                          fallbackIndex={index}
+                          isActive={isRunning && activePoolIndex === index + 1}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
               }
               editContent={
-                <div className="space-y-2">
-                  {pools.filter(p => p.badge !== 'coming-soon').map(pool => (
-                    <PoolOption
-                      key={pool.id}
-                      pool={pool}
-                      selected={!isCustomPool && editPool?.address === pool.address && editPool?.port === pool.port}
-                      onSelect={() => {
-                        setIsCustomPool(false);
-                        setEditPool(normalizePoolUserIdentity(
-                          knownPoolToConfig(pool, editPool?.user_identity ?? config.pool?.user_identity ?? ''),
-                          activeMiningMode,
-                        ));
-                      }}
-                    />
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsCustomPool(true);
-                      setEditPool(normalizePoolUserIdentity(
-                        createEmptyCustomPool(editPool?.user_identity ?? config.pool?.user_identity ?? ''),
+                <div className="space-y-6">
+                  <PoolPriorityEditor
+                    presets={pools}
+                    pools={editPools ?? []}
+                    miningMode={activeMiningMode}
+                    onChange={(nextPools) => {
+                      setEditPools((currentPools) => normalizePoolPriorityIdentities(
+                        nextPools,
+                        currentPools?.[0],
                         activeMiningMode,
                       ));
                     }}
-                    className={`w-full p-3 rounded-lg border transition-all text-left ${
-                      isCustomPool
-                        ? 'border-primary bg-primary/[0.04]'
-                        : 'border-border bg-card hover:border-primary/45'
-                    }`}
-                  >
-                    <div className="flex items-center justify-between">
+                  />
+
+                  {editPrimaryPool && (
+                    <div className="space-y-4 border-t border-border pt-5">
                       <div>
-                        <div className={`font-medium text-sm ${isCustomPool ? 'text-primary' : ''}`}>Custom Pool</div>
-                        <div className="text-xs text-muted-foreground">Enter your own pool connection details</div>
+                        <h3 className="text-sm font-semibold">Mining identity</h3>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Set the primary {identityLabel.toLowerCase()}. Fallback pools inherit it by default.
+                        </p>
                       </div>
-                      {isCustomPool && (
-                        <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
-                          <Check className="w-3 h-3 text-background" />
-                        </div>
+
+                      <div className="rounded-xl border border-border bg-muted/20 p-4">
+                        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                          Primary
+                        </p>
+                        <PoolIdentityFields
+                          pool={editPrimaryPool}
+                          miningMode={activeMiningMode}
+                          network={editNetwork}
+                          idPrefix="edit-primary-pool"
+                          onChange={(nextPool) => updateEditPoolIdentity(0, nextPool)}
+                        />
+                      </div>
+
+                      {editFallbackPools.length > 0 && (
+                        <FallbackIdentitySection
+                          primaryPool={editPrimaryPool}
+                          fallbackPools={editFallbackPools}
+                          presets={pools}
+                          miningMode={activeMiningMode}
+                          network={editNetwork}
+                          identityLabel={identityLabel}
+                          idPrefix="edit-fallback-identity"
+                          expanded={showFallbackIdentityFields || fallbackIdentityBlocked}
+                          hasBlockingError={fallbackIdentityBlocked}
+                          onToggle={() => setShowFallbackIdentityFields((current) => !current)}
+                          onChange={(index, nextPool) => updateEditPoolIdentity(index + 1, nextPool)}
+                        />
                       )}
                     </div>
-                  </button>
-                  {isCustomPool && (
-                    <div className="space-y-3 p-4 rounded-lg border border-border bg-muted/30">
-                      <div>
-                        <label htmlFor="edit-pool-address" className="block text-xs font-medium mb-1">Pool Address</label>
-                        <input
-                          id="edit-pool-address"
-                          type="text"
-                          value={editPool?.address ?? ''}
-                          onChange={e => setEditPool(prev => prev ? { ...prev, address: e.target.value } : prev)}
-                          placeholder="pool.example.com"
-                          className="w-full h-9 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-                        />
-                      </div>
-                      <div>
-                        <label htmlFor="edit-pool-port" className="block text-xs font-medium mb-1">Port</label>
-                        <input
-                          id="edit-pool-port"
-                          type="number"
-                          value={editPool?.port ?? DEFAULT_POOL_PORT}
-                          onChange={e => setEditPool(prev => prev ? { ...prev, port: parseInt(e.target.value) || DEFAULT_POOL_PORT } : prev)}
-                          className="w-full h-9 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-                        />
-                      </div>
-                      <div>
-                        <label htmlFor="edit-pool-pubkey" className="block text-xs font-medium mb-1">Authority Public Key</label>
-                        <input
-                          id="edit-pool-pubkey"
-                          type="text"
-                          value={editPool?.authority_public_key ?? ''}
-                          onChange={e => setEditPool(prev => prev ? { ...prev, authority_public_key: stripWrappingQuotes(e.target.value) } : prev)}
-                          placeholder="Enter pool's authority public key"
-                          className="w-full h-9 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-                        />
-                        {getPoolAuthorityPubkeyError(editPool?.authority_public_key ?? '') && (
-                          <p className="text-xs text-destructive mt-1">
-                            {getPoolAuthorityPubkeyError(editPool?.authority_public_key ?? '')}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  {editPool && (
-                    <PoolIdentityEdit
-                      pool={editPool}
-                      miningMode={activeMiningMode}
-                      network={editNetwork}
-                      idPrefix="edit-primary-pool"
-                      onChange={setEditPool}
-                    />
                   )}
                 </div>
-              }
-            />
-          )}
-
-          {/* Fallback pools */}
-          {!isSovereignSolo && (
-            <ConfigRow
-              label="Fallback Pools"
-              editing={editing === 'fallbackPools'}
-              onEdit={startEditFallbackPools}
-              onSave={saveEdit}
-              onCancel={cancelEdit}
-              isSaving={isSaving}
-              saveDisabled={!isFallbackPoolsValid}
-              disabled={editing !== null && editing !== 'fallbackPools'}
-              display={
-                <div className="space-y-2">
-                  {(config.fallbackPools ?? []).length === 0 ? (
-                    <p className="text-sm text-muted-foreground">None</p>
-                  ) : (
-                    config.fallbackPools.map((pool, index) => (
-                      <PoolSummary
-                        key={`${pool.address}:${pool.port}:${index}`}
-                        pool={pool}
-                        miningMode={activeMiningMode}
-                        fallbackIndex={index}
-                        isActive={isRunning && activePoolIndex === index + 1}
-                      />
-                    ))
-                  )}
-                </div>
-              }
-              editContent={
-                <FallbackPoolsEdit
-                  pools={editFallbackPools ?? []}
-                  availablePools={pools}
-                  miningMode={activeMiningMode}
-                  network={editNetwork}
-                  onChange={setEditFallbackPools}
-                />
               }
             />
           )}
@@ -1041,613 +965,5 @@ function PoolSummary({
         </p>
       </div>
     </div>
-  );
-}
-
-function PoolIdentityEdit({
-  pool,
-  miningMode,
-  network,
-  idPrefix,
-  onChange,
-}: {
-  pool: PoolConfig;
-  miningMode: SetupData['miningMode'];
-  network: NonNullable<SetupData['bitcoin']>['network'];
-  idPrefix: string;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  if (miningMode === 'solo' && isSriPool(pool)) {
-    return (
-      <SriPoolIdentityEdit
-        pool={pool}
-        network={network}
-        idPrefix={idPrefix}
-        onChange={onChange}
-      />
-    );
-  }
-
-  const error = getPoolIdentityError(pool, miningMode, network);
-  const label = 'Username';
-  const placeholder = miningMode === 'solo' ? getBitcoinAddressPlaceholder(network) : 'username.worker1';
-
-  return (
-    <div>
-      <label htmlFor={`${idPrefix}-identity`} className="block text-xs font-medium mb-1">{label}</label>
-      <input
-        id={`${idPrefix}-identity`}
-        type="text"
-        value={pool.user_identity}
-        onChange={(e) => onChange({ ...pool, user_identity: e.target.value })}
-        placeholder={placeholder}
-        className="w-full h-9 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-      />
-      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
-    </div>
-  );
-}
-
-function SriPoolIdentityEdit({
-  pool,
-  network,
-  idPrefix,
-  onChange,
-}: {
-  pool: PoolConfig;
-  network: NonNullable<SetupData['bitcoin']>['network'];
-  idPrefix: string;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  const parsed = parseSriIdentity(pool.user_identity);
-  const needsAddress = parsed.donationPercent < 100;
-  const identityError = getPoolIdentityError(pool, 'solo', network);
-
-  useEffect(() => {
-    const normalizedPool = normalizePoolUserIdentity(pool, 'solo');
-    if (normalizedPool !== pool) {
-      onChange(normalizedPool);
-    }
-  }, [onChange, pool]);
-
-  const updateSriIdentity = (address: string, workerName: string, donationPercent: number) => {
-    onChange({
-      ...pool,
-      user_identity: buildSriIdentity(address, workerName, donationPercent),
-    });
-  };
-
-  return (
-    <div className="space-y-3">
-      {needsAddress && (
-        <div>
-          <label htmlFor={`${idPrefix}-payout-address`} className="block text-xs font-medium mb-1">
-            Username
-          </label>
-          <input
-            id={`${idPrefix}-payout-address`}
-            type="text"
-            value={parsed.address}
-            onChange={(event) => updateSriIdentity(event.target.value, parsed.workerName, parsed.donationPercent)}
-            placeholder={getBitcoinAddressPlaceholder(network)}
-            aria-required="true"
-            autoComplete="off"
-            className="w-full h-9 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-          />
-          {getBitcoinAddressError(parsed.address, network) && (
-            <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(parsed.address, network)}</p>
-          )}
-        </div>
-      )}
-
-      <div>
-        <label htmlFor={`${idPrefix}-worker-name`} className="block text-xs font-medium mb-1">
-          Worker Name <span className="text-muted-foreground font-normal">(optional)</span>
-        </label>
-        <input
-          id={`${idPrefix}-worker-name`}
-          type="text"
-          value={parsed.workerName}
-          onChange={(event) => updateSriIdentity(parsed.address, event.target.value, parsed.donationPercent)}
-          placeholder="worker1"
-          autoComplete="off"
-          className="w-full h-9 px-3 rounded-lg border border-input bg-background font-mono text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-        />
-      </div>
-
-      <div>
-        <label htmlFor={`${idPrefix}-donation-slider`} className="block text-xs font-medium mb-1">
-          Donation to SRI Development <span className="text-muted-foreground font-normal">(optional)</span>
-        </label>
-        <div className="p-3 rounded-lg bg-muted/40 space-y-2">
-          <input
-            id={`${idPrefix}-donation-slider`}
-            type="range"
-            min={0}
-            max={100}
-            value={parsed.donationPercent}
-            onChange={(event) => updateSriIdentity(parsed.address, parsed.workerName, snapDonation(Number(event.target.value)))}
-            aria-label={`Donation: ${parsed.donationPercent}%`}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={parsed.donationPercent}
-            className="w-full accent-primary"
-            list={`${idPrefix}-donation-snap-points`}
-          />
-          <datalist id={`${idPrefix}-donation-snap-points`}>
-            <option value="0" />
-            <option value="10" />
-            <option value="25" />
-            <option value="50" />
-            <option value="75" />
-            <option value="100" />
-          </datalist>
-          <div className="flex justify-between text-xs text-muted-foreground select-none">
-            <span>0%</span><span>25%</span><span>50%</span><span>75%</span><span>100%</span>
-          </div>
-        </div>
-        <p className="text-xs text-muted-foreground mt-2">
-          {parsed.donationPercent === 0
-            ? 'Full block reward goes to your payout address'
-            : parsed.donationPercent >= 100
-              ? 'Full block reward is donated to SRI development'
-              : `${parsed.donationPercent}% of the block reward goes to SRI development, ${100 - parsed.donationPercent}% to your address`}
-        </p>
-      </div>
-
-      {identityError && <p className="text-xs text-destructive">{identityError}</p>}
-    </div>
-  );
-}
-
-function FallbackPoolsEdit({
-  pools,
-  availablePools,
-  miningMode,
-  network,
-  onChange,
-}: {
-  pools: PoolConfig[];
-  availablePools: KnownPool[];
-  miningMode: SetupData['miningMode'];
-  network: NonNullable<SetupData['bitcoin']>['network'];
-  onChange: (pools: PoolConfig[]) => void;
-}) {
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-  const draggedIndexRef = useRef<number | null>(null);
-
-  const updatePool = (index: number, nextPool: PoolConfig) => {
-    onChange(pools.map((pool, i) => (
-      i === index ? normalizePoolUserIdentity(nextPool, miningMode) : pool
-    )));
-  };
-
-  const removePool = (index: number) => {
-    onChange(pools.filter((_, i) => i !== index));
-  };
-
-  const movePool = (fromIndex: number, toIndex: number) => {
-    if (fromIndex === toIndex || toIndex < 0 || toIndex >= pools.length) {
-      return;
-    }
-
-    const nextPools = [...pools];
-    const [movedPool] = nextPools.splice(fromIndex, 1);
-    nextPools.splice(toIndex, 0, movedPool);
-    onChange(nextPools);
-  };
-
-  const availablePreset = availablePools.find((pool) => (
-    pool.badge !== 'coming-soon' &&
-    !pools.some((usedPool) => isSamePool(usedPool, pool))
-  ));
-
-  const addPresetPool = () => {
-    if (!availablePreset) return;
-    onChange([
-      ...pools,
-      normalizePoolUserIdentity(
-        knownPoolToConfig(availablePreset),
-        miningMode,
-      ),
-    ]);
-  };
-
-  const addCustomPool = () => {
-    onChange([
-      ...pools,
-      normalizePoolUserIdentity(
-        createEmptyCustomPool(),
-        miningMode,
-      ),
-    ]);
-  };
-
-  const finishDrag = (toIndex: number) => {
-    if (draggedIndexRef.current !== null) {
-      movePool(draggedIndexRef.current, toIndex);
-    }
-    draggedIndexRef.current = null;
-    setDraggedIndex(null);
-    setDragOverIndex(null);
-  };
-
-  return (
-    <div className="space-y-3">
-      {pools.length === 0 && (
-        <p className="text-sm text-muted-foreground">No fallback pools configured.</p>
-      )}
-
-      {pools.map((pool, index) => (
-        <SettingsFallbackPoolRow
-          key={`fallback-pool-${index}`}
-          pool={pool}
-          index={index}
-          totalPools={pools.length}
-          availablePools={availablePools}
-          miningMode={miningMode}
-          network={network}
-          isDragging={draggedIndex === index}
-          isDragTarget={dragOverIndex === index && draggedIndex !== index}
-          onDragStart={(event) => {
-            draggedIndexRef.current = index;
-            setDraggedIndex(index);
-            setDragOverIndex(index);
-            event.dataTransfer.effectAllowed = 'move';
-            event.dataTransfer.setData('text/plain', String(index));
-          }}
-          onDragEnter={() => {
-            if (draggedIndexRef.current !== null && draggedIndexRef.current !== index) {
-              setDragOverIndex(index);
-            }
-          }}
-          onDragOver={(event) => {
-            event.preventDefault();
-            event.dataTransfer.dropEffect = 'move';
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            finishDrag(index);
-          }}
-          onDragEnd={() => {
-            draggedIndexRef.current = null;
-            setDraggedIndex(null);
-            setDragOverIndex(null);
-          }}
-          onMoveUp={() => movePool(index, index - 1)}
-          onMoveDown={() => movePool(index, index + 1)}
-          onRemove={() => removePool(index)}
-          onChange={(nextPool) => updatePool(index, nextPool)}
-        />
-      ))}
-
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={addPresetPool}
-          disabled={!availablePreset}
-        >
-          Add Preset Pool
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={addCustomPool}
-        >
-          Add Custom Pool
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function SettingsFallbackPoolRow({
-  pool,
-  index,
-  totalPools,
-  availablePools,
-  miningMode,
-  network,
-  isDragging,
-  isDragTarget,
-  onDragStart,
-  onDragEnter,
-  onDragOver,
-  onDrop,
-  onDragEnd,
-  onMoveUp,
-  onMoveDown,
-  onRemove,
-  onChange,
-}: {
-  pool: PoolConfig;
-  index: number;
-  totalPools: number;
-  availablePools: KnownPool[];
-  miningMode: SetupData['miningMode'];
-  network: NonNullable<SetupData['bitcoin']>['network'];
-  isDragging: boolean;
-  isDragTarget: boolean;
-  onDragStart: (event: DragEvent<HTMLButtonElement>) => void;
-  onDragEnter: () => void;
-  onDragOver: (event: DragEvent<HTMLDivElement>) => void;
-  onDrop: (event: DragEvent<HTMLDivElement>) => void;
-  onDragEnd: () => void;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
-  onRemove: () => void;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  const selectedPreset = availablePools.find((preset) => isSamePool(pool, preset)) ?? null;
-  const knownPool = selectedPreset ?? getKnownPoolForConfig(pool);
-  const isCustom = !selectedPreset;
-  const selectedPoolValue = selectedPreset?.id ?? 'custom';
-  const displayName = (knownPool?.name ?? pool.name) || `Fallback Pool ${index + 1}`;
-  const endpoint = `${pool.address || 'pool.example.com'}:${pool.port || DEFAULT_POOL_PORT}`;
-  const identityError = getPoolIdentityError(pool, miningMode, network);
-  const usesSriIdentity = miningMode === 'solo' && isSriPool(pool);
-
-  const updateField = (field: keyof PoolConfig, value: string | number) => {
-    const normalized =
-      field === 'authority_public_key' && typeof value === 'string'
-        ? stripWrappingQuotes(value)
-        : value;
-    onChange({ ...pool, [field]: normalized });
-  };
-
-  const handlePoolSelection = (poolId: string) => {
-    if (poolId === 'custom') {
-      onChange(createEmptyCustomPool(pool.user_identity));
-      return;
-    }
-
-    const preset = availablePools.find((item) => item.id === poolId);
-    if (preset && preset.badge !== 'coming-soon') {
-      onChange(knownPoolToConfig(preset, pool.user_identity));
-    }
-  };
-
-  const pubkeyError = getPoolAuthorityPubkeyError(pool.authority_public_key);
-
-  return (
-    <div
-      onDragEnter={onDragEnter}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      className={`rounded-lg border bg-muted/30 transition-colors ${
-        isDragTarget
-          ? 'border-primary bg-primary/[0.04]'
-          : 'border-border'
-      } ${isDragging ? 'opacity-60' : ''}`}
-    >
-      <div className="grid grid-cols-[auto_auto_minmax(0,1fr)_auto] gap-3 p-4 md:grid-cols-[auto_auto_minmax(0,1fr)_minmax(0,1.1fr)_auto] md:items-start">
-        <button
-          type="button"
-          draggable
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          className="inline-flex h-11 w-9 cursor-grab items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-          aria-label={`Drag fallback pool ${index + 1} to reorder`}
-          title="Drag to reorder fallback priority"
-        >
-          <GripVertical className="h-5 w-5" aria-hidden="true" />
-        </button>
-
-        <div className="inline-flex h-11 min-w-9 items-center justify-center rounded-lg bg-background/70 px-2 text-xs font-semibold text-muted-foreground">
-          {index + 1}
-        </div>
-
-        <div className="flex min-w-0 items-start gap-3">
-          <PoolIcon
-            logoUrl={knownPool?.logoUrl}
-            logoOnDark={knownPool?.logoOnDark}
-            monogram={knownPool?.monogram}
-            invertLogoInDarkMode={knownPool?.invertLogoInDarkMode}
-            logoScale={knownPool?.logoScale}
-            name={displayName}
-            className="h-11 w-11 rounded-xl"
-          />
-          <div className="min-w-0 flex-1">
-            <label htmlFor={`fallback-${index}-preset`} className="sr-only">
-              Pool for fallback priority {index + 1}
-            </label>
-            <select
-              id={`fallback-${index}-preset`}
-              value={selectedPoolValue}
-              onChange={(event) => handlePoolSelection(event.target.value)}
-              className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-            >
-              {availablePools.map((preset) => (
-                <option key={preset.id} value={preset.id} disabled={preset.badge === 'coming-soon'}>
-                  {preset.name}{preset.badge === 'coming-soon' ? ' (coming soon)' : ''}
-                </option>
-              ))}
-              <option value="custom">Custom Pool</option>
-            </select>
-            <p className="mt-1 truncate text-xs text-muted-foreground font-mono">{endpoint}</p>
-          </div>
-        </div>
-
-        <div className="col-span-2 col-start-3 min-w-0 md:col-span-1 md:col-start-auto">
-          <label htmlFor={`fallback-${index}-identity`} className="sr-only">
-            Username for fallback pool {index + 1}
-          </label>
-          {usesSriIdentity ? (
-            <div className="flex min-h-10 items-center rounded-lg border border-border bg-background px-3 font-mono text-xs text-muted-foreground">
-              <span className="truncate">{getPoolUserIdentityDisplay(pool, miningMode)}</span>
-            </div>
-          ) : (
-            <>
-              <input
-                id={`fallback-${index}-identity`}
-                type="text"
-                value={pool.user_identity}
-                onChange={(event) => onChange({ ...pool, user_identity: event.target.value })}
-                placeholder={miningMode === 'solo' ? getBitcoinAddressPlaceholder(network) : 'username.worker1'}
-                aria-required="true"
-                autoComplete="off"
-                className={`h-10 w-full rounded-lg border bg-background px-3 font-mono text-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-primary/15 ${
-                  identityError ? 'border-destructive focus-visible:border-destructive' : 'border-input focus-visible:border-primary'
-                }`}
-              />
-              {identityError && <p className="mt-1 text-xs text-destructive">{identityError}</p>}
-            </>
-          )}
-        </div>
-
-        <div className="col-start-4 row-start-1 flex h-11 shrink-0 items-center justify-end gap-1 md:col-start-auto md:row-start-auto">
-          <button
-            type="button"
-            onClick={onMoveUp}
-            disabled={index === 0}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-            aria-label={`Move fallback pool ${index + 1} up`}
-            title="Move up"
-          >
-            <ArrowUp className="h-4 w-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onMoveDown}
-            disabled={index === totalPools - 1}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-            aria-label={`Move fallback pool ${index + 1} down`}
-            title="Move down"
-          >
-            <ArrowDown className="h-4 w-4" aria-hidden="true" />
-          </button>
-          <button
-            type="button"
-            onClick={onRemove}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-            aria-label={`Remove fallback pool ${index + 1}`}
-            title="Remove fallback pool"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-      </div>
-
-      {usesSriIdentity && (
-        <div className="border-t border-border bg-background/40 p-4">
-          <SriPoolIdentityEdit
-            pool={pool}
-            network={network}
-            idPrefix={`fallback-${index}`}
-            onChange={onChange}
-          />
-        </div>
-      )}
-
-      {isCustom && (
-        <div className="border-t border-border bg-background/40 p-3">
-          <div className="grid gap-2 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)_7rem_minmax(0,1.3fr)]">
-            <div>
-              <label htmlFor={`fallback-${index}-name`} className="mb-1 block text-xs font-medium text-muted-foreground">
-                Name
-              </label>
-              <input
-                id={`fallback-${index}-name`}
-                type="text"
-                value={pool.name}
-                onChange={(event) => updateField('name', event.target.value)}
-                className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-              />
-            </div>
-
-            <div>
-              <label htmlFor={`fallback-${index}-address`} className="mb-1 block text-xs font-medium text-muted-foreground">
-                Address
-              </label>
-              <input
-                id={`fallback-${index}-address`}
-                type="text"
-                value={pool.address}
-                onChange={(event) => updateField('address', event.target.value)}
-                placeholder="pool.example.com"
-                className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-              />
-            </div>
-
-            <div>
-              <label htmlFor={`fallback-${index}-port`} className="mb-1 block text-xs font-medium text-muted-foreground">
-                Port
-              </label>
-              <input
-                id={`fallback-${index}-port`}
-                type="number"
-                value={pool.port}
-                onChange={(event) => updateField('port', parseInt(event.target.value, 10) || DEFAULT_POOL_PORT)}
-                className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-              />
-            </div>
-
-            <div>
-              <label htmlFor={`fallback-${index}-pubkey`} className="mb-1 block text-xs font-medium text-muted-foreground">
-                Authority Public Key
-              </label>
-              <input
-                id={`fallback-${index}-pubkey`}
-                type="text"
-                value={pool.authority_public_key}
-                onChange={(event) => updateField('authority_public_key', event.target.value)}
-                placeholder="Pool authority public key"
-                className={`h-9 w-full rounded-lg border bg-background px-3 font-mono text-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-primary/15 ${
-                  pubkeyError ? 'border-destructive focus-visible:border-destructive' : 'border-input focus-visible:border-primary'
-                }`}
-              />
-              {pubkeyError && <p className="mt-1 text-xs text-destructive">{pubkeyError}</p>}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Pool selection option for inline editing.
- */
-function PoolOption({
-  pool,
-  selected,
-  onSelect,
-}: {
-  pool: KnownPool;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={`w-full p-3 rounded-lg border transition-all text-left flex items-center gap-3 ${
-        selected
-          ? 'border-primary bg-primary/[0.04]'
-          : 'border-border bg-card hover:border-primary/45'
-      }`}
-    >
-      <PoolIcon
-        logoUrl={pool.logoUrl}
-        logoOnDark={pool.logoOnDark}
-        monogram={pool.monogram}
-        invertLogoInDarkMode={pool.invertLogoInDarkMode}
-        logoScale={pool.logoScale}
-        name={pool.name}
-      />
-      <div className="flex-1 min-w-0">
-        <div className={`font-medium text-sm ${selected ? 'text-primary' : ''}`}>{pool.name}</div>
-        <div className="text-xs text-muted-foreground font-mono">{pool.address}:{pool.port}</div>
-      </div>
-      {selected && (
-        <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
-          <Check className="w-3 h-3 text-background" />
-        </div>
-      )}
-    </button>
   );
 }

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -593,7 +593,7 @@ export function ConfigurationTab() {
                   {(config.fallbackPools ?? []).length > 0 && (
                     <div className="space-y-2 border-t border-border/60 pt-3">
                       <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        Fallback priority
+                        Fallback
                       </p>
                       {config.fallbackPools.map((pool, index) => (
                         <PoolSummary

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -1238,16 +1238,27 @@ function FallbackPoolsEdit({
     onChange(nextPools);
   };
 
-  const addPool = () => {
-    const availablePreset = availablePools.find((pool) => (
-      pool.badge !== 'coming-soon' &&
-      !pools.some((usedPool) => isSamePool(usedPool, pool))
-    ));
+  const availablePreset = availablePools.find((pool) => (
+    pool.badge !== 'coming-soon' &&
+    !pools.some((usedPool) => isSamePool(usedPool, pool))
+  ));
 
+  const addPresetPool = () => {
+    if (!availablePreset) return;
     onChange([
       ...pools,
       normalizePoolUserIdentity(
-        availablePreset ? knownPoolToConfig(availablePreset) : createEmptyCustomPool(),
+        knownPoolToConfig(availablePreset),
+        miningMode,
+      ),
+    ]);
+  };
+
+  const addCustomPool = () => {
+    onChange([
+      ...pools,
+      normalizePoolUserIdentity(
+        createEmptyCustomPool(),
         miningMode,
       ),
     ]);
@@ -1311,14 +1322,25 @@ function FallbackPoolsEdit({
         />
       ))}
 
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={addPool}
-      >
-        Add Fallback Pool
-      </Button>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addPresetPool}
+          disabled={!availablePreset}
+        >
+          Add Preset Pool
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addCustomPool}
+        >
+          Add Custom Pool
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/setup/steps/PoolConfigStep.tsx
+++ b/src/components/setup/steps/PoolConfigStep.tsx
@@ -1,38 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import { StepProps, PoolConfig, BitcoinNetwork, MiningMode } from '../types';
-import { DEFAULT_POOL_PORT } from '@sv2-ui/shared';
-import { AlertCircle, ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
-import { shouldAggregateTranslatorChannels } from '../poolRules';
+import { useState } from 'react';
+import { StepProps, PoolConfig, MiningMode } from '../types';
 import { PoolIcon } from '@/components/ui/pool-icon';
+import { FallbackIdentitySection } from '@/components/pools/FallbackIdentitySection';
+import { PoolIdentityFields } from '@/components/pools/PoolIdentityFields';
+import { PoolPriorityEditor } from '@/components/pools/PoolPriorityEditor';
 import {
-  createEmptyCustomPool,
   getPoolsForMode,
   isSamePool,
-  knownPoolToConfig,
   type KnownPool,
 } from '@/lib/pools';
-import {
-  buildSriIdentity,
-  getPoolIdentityError,
-  isSriPool,
-  normalizePoolUserIdentity,
-  parseSriIdentity,
-} from '@/lib/miningIdentity';
-import {
-  getBitcoinAddressError,
-  getBitcoinAddressPlaceholder,
-  getPoolAuthorityPubkeyError,
-  isValidPoolAuthorityPubkey,
-  stripWrappingQuotes,
-} from '@/lib/utils';
-
-const DONATION_SNAP_POINTS = [0, 10, 25, 50, 75, 100];
-const DONATION_SNAP_THRESHOLD = 3;
-
-function snapDonation(value: number): number {
-  const nearest = DONATION_SNAP_POINTS.find((p) => Math.abs(value - p) <= DONATION_SNAP_THRESHOLD);
-  return nearest ?? value;
-}
+import { normalizePoolPriorityIdentities } from '@/lib/miningIdentity';
+import { isPoolComplete, isPoolConnectionComplete } from '@/lib/poolValidation';
 
 function poolMatchesPreset(pool: PoolConfig | null | undefined, preset: KnownPool): boolean {
   return isSamePool(pool, preset);
@@ -42,70 +20,12 @@ function getSelectedPreset(pool: PoolConfig | null | undefined, pools: KnownPool
   return pools.find((preset) => poolMatchesPreset(pool, preset)) ?? null;
 }
 
-function isPoolComplete(
-  pool: PoolConfig | null | undefined,
-  miningMode: MiningMode | null,
-  network: BitcoinNetwork,
-): boolean {
-  return Boolean(
-    pool?.address &&
-    Number.isInteger(pool.port) &&
-    pool.port > 0 &&
-    pool.port <= 65535 &&
-    isValidPoolAuthorityPubkey(pool.authority_public_key) &&
-    !getPoolIdentityError(pool, miningMode, network),
-  );
-}
-
-function isPoolConnectionComplete(pool: PoolConfig | null | undefined): boolean {
-  return Boolean(
-    pool?.address &&
-    Number.isInteger(pool.port) &&
-    pool.port > 0 &&
-    pool.port <= 65535 &&
-    isValidPoolAuthorityPubkey(pool.authority_public_key),
-  );
-}
-
 function getIdentityFieldLabel(miningMode: MiningMode | null): string {
   return miningMode === 'solo' ? 'Payout address' : 'Pool username';
 }
 
 function getIdentityStepTitle(miningMode: MiningMode | null): string {
   return miningMode === 'solo' ? 'Add Payout Address' : 'Add Pool Username';
-}
-
-function getFallbackDefaultIdentity(
-  primaryPool: PoolConfig | null | undefined,
-  fallbackPool: PoolConfig,
-  miningMode: MiningMode | null,
-): string {
-  const primaryIdentity = primaryPool?.user_identity ?? '';
-  if (!primaryIdentity) return '';
-
-  if (miningMode === 'solo' && isSriPool(primaryPool) && !isSriPool(fallbackPool)) {
-    const parsed = parseSriIdentity(primaryIdentity);
-    return parsed.donationPercent >= 100 ? '' : parsed.address;
-  }
-
-  return normalizePoolUserIdentity(
-    { ...fallbackPool, user_identity: primaryIdentity },
-    miningMode,
-  ).user_identity;
-}
-
-function withFallbackDefaultIdentity(
-  primaryPool: PoolConfig | null | undefined,
-  fallbackPool: PoolConfig,
-  miningMode: MiningMode | null,
-): PoolConfig {
-  return normalizePoolUserIdentity(
-    {
-      ...fallbackPool,
-      user_identity: getFallbackDefaultIdentity(primaryPool, fallbackPool, miningMode),
-    },
-    miningMode,
-  );
 }
 
 type PoolConfigStepProps = StepProps;
@@ -125,20 +45,16 @@ export function PoolConfigStep({ data, updateData, onNext }: PoolConfigStepProps
   const selectedPreset = getSelectedPreset(primaryPool, pools);
 
   const updateSelectedPools = (nextPools: PoolConfig[]) => {
-    const normalizedPools = nextPools.map((pool) => normalizePoolUserIdentity(pool, data.miningMode));
+    const normalizedPools = normalizePoolPriorityIdentities(
+      nextPools,
+      primaryPool,
+      data.miningMode,
+    );
     const nextPrimaryPool = normalizedPools[0] ?? null;
 
     updateData({
       pool: nextPrimaryPool,
-      fallbackPools: normalizedPools.slice(1).map((fallbackPool) => {
-        const previousDefaultIdentity = getFallbackDefaultIdentity(primaryPool, fallbackPool, data.miningMode);
-
-        if (fallbackPool.user_identity && fallbackPool.user_identity !== previousDefaultIdentity) {
-          return fallbackPool;
-        }
-
-        return withFallbackDefaultIdentity(nextPrimaryPool, fallbackPool, data.miningMode);
-      }),
+      fallbackPools: normalizedPools.slice(1),
     });
   };
 
@@ -150,43 +66,6 @@ export function PoolConfigStep({ data, updateData, onNext }: PoolConfigStepProps
     updateSelectedPools(selectedPools.map((item, i) => (
       i === index + 1 ? pool : item
     )));
-  };
-
-  const updateSelectedPool = (index: number, pool: PoolConfig) => {
-    updateSelectedPools(selectedPools.map((item, i) => (
-      i === index ? pool : item
-    )));
-  };
-
-  const moveSelectedPool = (fromIndex: number, toIndex: number) => {
-    if (fromIndex === toIndex || toIndex < 0 || toIndex >= selectedPools.length) {
-      return;
-    }
-
-    const nextPools = [...selectedPools];
-    const [movedPool] = nextPools.splice(fromIndex, 1);
-    nextPools.splice(toIndex, 0, movedPool);
-    updateSelectedPools(nextPools);
-  };
-
-  const toggleKnownPool = (pool: KnownPool) => {
-    const selectedIndex = selectedPools.findIndex((selectedPool) => isSamePool(selectedPool, pool));
-    if (selectedIndex >= 0) {
-      updateSelectedPools(selectedPools.filter((_, index) => index !== selectedIndex));
-      return;
-    }
-
-    updateSelectedPools([...selectedPools, knownPoolToConfig(pool, primaryPool?.user_identity ?? '')]);
-  };
-
-  const toggleCustomPool = () => {
-    const selectedIndex = selectedPools.findIndex((pool) => !getSelectedPreset(pool, pools));
-    if (selectedIndex >= 0) {
-      updateSelectedPools(selectedPools.filter((_, index) => index !== selectedIndex));
-      return;
-    }
-
-    updateSelectedPools([...selectedPools, createEmptyCustomPool(primaryPool?.user_identity ?? '')]);
   };
 
   const poolSelectionValid =
@@ -225,23 +104,19 @@ export function PoolConfigStep({ data, updateData, onNext }: PoolConfigStepProps
           />
         )}
 
-        {fallbackPools.length > 0 && (
+        {primaryPool && fallbackPools.length > 0 && (
           <FallbackIdentitySection
+            primaryPool={primaryPool}
             fallbackPools={fallbackPools}
-            pools={pools}
+            presets={pools}
             miningMode={data.miningMode}
             network={network}
             identityLabel={identityLabel}
+            idPrefix="setup-fallback-identity"
             expanded={showFallbackIdentityFields || fallbackIdentityBlocked}
             hasBlockingError={fallbackIdentityBlocked}
             onToggle={() => setShowFallbackIdentityFields((current) => !current)}
             onChange={updateFallbackPool}
-            onUsePrimary={(index) => {
-              const fallbackPool = fallbackPools[index];
-              if (fallbackPool) {
-                updateFallbackPool(index, withFallbackDefaultIdentity(primaryPool, fallbackPool, data.miningMode));
-              }
-            }}
           />
         )}
 
@@ -278,13 +153,11 @@ export function PoolConfigStep({ data, updateData, onNext }: PoolConfigStepProps
       </div>
 
       <div className="space-y-3">
-        <PoolPriorityList
-          pools={pools}
-          selectedPools={selectedPools}
-          onTogglePool={toggleKnownPool}
-          onToggleCustom={toggleCustomPool}
-          onMove={moveSelectedPool}
-          onChangeSelectedPool={updateSelectedPool}
+        <PoolPriorityEditor
+          presets={pools}
+          pools={selectedPools}
+          miningMode={data.miningMode}
+          onChange={updateSelectedPools}
         />
       </div>
 
@@ -338,592 +211,6 @@ function SelectedPoolSummary({
       >
         Change
       </button>
-    </div>
-  );
-}
-
-function FallbackIdentitySection({
-  fallbackPools,
-  pools,
-  miningMode,
-  network,
-  identityLabel,
-  expanded,
-  hasBlockingError,
-  onToggle,
-  onChange,
-  onUsePrimary,
-}: {
-  fallbackPools: PoolConfig[];
-  pools: KnownPool[];
-  miningMode: PoolConfigStepProps['data']['miningMode'];
-  network: BitcoinNetwork;
-  identityLabel: string;
-  expanded: boolean;
-  hasBlockingError: boolean;
-  onToggle: () => void;
-  onChange: (index: number, pool: PoolConfig) => void;
-  onUsePrimary: (index: number) => void;
-}) {
-  if (!expanded) {
-    return (
-      <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <span>Fallback pools will use this same {identityLabel.toLowerCase()}.</span>
-          <button
-            type="button"
-            onClick={onToggle}
-            className="self-start rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:self-auto"
-          >
-            Customize
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className={`space-y-4 rounded-lg border p-4 ${
-      hasBlockingError
-        ? 'border-destructive/40 bg-destructive/[0.08]'
-        : 'border-border bg-muted/20'
-    }`}>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h3 className="text-sm font-semibold">Fallback identities</h3>
-          <p className={`mt-1 text-sm ${hasBlockingError ? 'text-destructive' : 'text-muted-foreground'}`}>
-            {hasBlockingError
-              ? `Set a valid fallback ${identityLabel.toLowerCase()} or remove fallback pools.`
-              : 'Optional. Leave these matching the primary value unless a fallback pool needs a different one.'}
-          </p>
-        </div>
-        {!hasBlockingError && (
-          <button
-            type="button"
-            onClick={onToggle}
-            className="self-start rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:self-auto"
-          >
-            Hide
-          </button>
-        )}
-      </div>
-
-      <div className="space-y-4">
-        {fallbackPools.map((pool, index) => {
-          const selectedPreset = getSelectedPreset(pool, pools);
-          const displayName = selectedPreset?.name ?? pool.name ?? `Fallback ${index + 1}`;
-
-          return (
-            <div key={`fallback-identity-${index}`} className="rounded-lg border border-border bg-card p-4">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-3">
-                  <PoolIcon
-                    logoUrl={selectedPreset?.logoUrl}
-                    logoOnDark={selectedPreset?.logoOnDark}
-                    monogram={selectedPreset?.monogram}
-                    invertLogoInDarkMode={selectedPreset?.invertLogoInDarkMode}
-                    logoScale={selectedPreset?.logoScale}
-                    name={displayName}
-                  />
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{displayName}</div>
-                    <div className="truncate font-mono text-xs text-muted-foreground">
-                      {pool.address}:{pool.port}
-                    </div>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => onUsePrimary(index)}
-                  className="shrink-0 rounded-lg border border-border px-3 py-2 text-xs font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                >
-                  Use primary
-                </button>
-              </div>
-
-              <PoolIdentityFields
-                pool={pool}
-                miningMode={miningMode}
-                network={network}
-                idPrefix={`fallback-identity-${index}`}
-                onChange={(nextPool) => onChange(index, nextPool)}
-              />
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function PoolPriorityList({
-  pools,
-  selectedPools,
-  onTogglePool,
-  onToggleCustom,
-  onMove,
-  onChangeSelectedPool,
-}: {
-  pools: KnownPool[];
-  selectedPools: PoolConfig[];
-  onTogglePool: (pool: KnownPool) => void;
-  onToggleCustom: () => void;
-  onMove: (fromIndex: number, toIndex: number) => void;
-  onChangeSelectedPool: (index: number, pool: PoolConfig) => void;
-}) {
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-  const draggedIndexRef = useRef<number | null>(null);
-  const selectedCustomIndex = selectedPools.findIndex((pool) => !getSelectedPreset(pool, pools));
-  const unselectedPools = pools.filter((pool) => !selectedPools.some((selectedPool) => isSamePool(selectedPool, pool)));
-
-  const finishDrag = (toIndex: number) => {
-    if (draggedIndexRef.current !== null) {
-      onMove(draggedIndexRef.current, toIndex);
-    }
-    draggedIndexRef.current = null;
-    setDraggedIndex(null);
-    setDragOverIndex(null);
-  };
-
-  return (
-    <div className="space-y-2">
-      {selectedPools.map((pool, index) => {
-        const preset = getSelectedPreset(pool, pools);
-        const isCustom = !preset;
-        const displayName = preset?.name ?? pool.name ?? 'Custom Pool';
-
-        return (
-          <div
-            key={`selected-pool-${index}`}
-            onDragEnter={() => {
-              if (draggedIndexRef.current !== null && draggedIndexRef.current !== index) {
-                setDragOverIndex(index);
-              }
-            }}
-            onDragOver={(event) => {
-              event.preventDefault();
-              event.dataTransfer.dropEffect = 'move';
-            }}
-            onDrop={(event) => {
-              event.preventDefault();
-              finishDrag(index);
-            }}
-            className={`rounded-xl border bg-card transition-colors ${
-              dragOverIndex === index && draggedIndex !== index
-                ? 'border-primary bg-primary/[0.04]'
-                : 'border-primary/70'
-            } ${draggedIndex === index ? 'opacity-60' : ''}`}
-          >
-            <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 p-4">
-              <button
-                type="button"
-                draggable
-                onDragStart={(event) => {
-                  draggedIndexRef.current = index;
-                  setDraggedIndex(index);
-                  setDragOverIndex(index);
-                  event.dataTransfer.effectAllowed = 'move';
-                  event.dataTransfer.setData('text/plain', String(index));
-                }}
-                onDragEnd={() => {
-                  draggedIndexRef.current = null;
-                  setDraggedIndex(null);
-                  setDragOverIndex(null);
-                }}
-                className="inline-flex h-11 w-9 cursor-grab items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                aria-label={`Drag ${displayName} to reorder pool priority`}
-                title="Drag to reorder priority"
-              >
-                <GripVertical className="h-5 w-5" aria-hidden="true" />
-              </button>
-
-              <div className="flex min-w-0 items-center gap-4">
-                <PoolIcon
-                  logoUrl={preset?.logoUrl}
-                  logoOnDark={preset?.logoOnDark}
-                  monogram={preset?.monogram}
-                  invertLogoInDarkMode={preset?.invertLogoInDarkMode}
-                  logoScale={preset?.logoScale}
-                  name={displayName}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="truncate text-sm font-medium text-primary">{displayName}</span>
-                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-                      {index === 0 ? 'Primary' : `Fallback ${index}`}
-                    </span>
-                  </div>
-                  {pool.address && (
-                    <div className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                      {pool.address}:{pool.port}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex shrink-0 items-center gap-1">
-                <button
-                  type="button"
-                  onClick={() => onMove(index, index - 1)}
-                  disabled={index === 0}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                  aria-label={`Move ${displayName} up`}
-                  title="Move up"
-                >
-                  <ArrowUp className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onMove(index, index + 1)}
-                  disabled={index === selectedPools.length - 1}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                  aria-label={`Move ${displayName} down`}
-                  title="Move down"
-                >
-                  <ArrowDown className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (preset) {
-                      onTogglePool(preset);
-                    } else {
-                      onToggleCustom();
-                    }
-                  }}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                  aria-label={`Remove ${displayName} from pool priority`}
-                  title="Remove"
-                >
-                  <X className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </div>
-            </div>
-
-            {isCustom && (
-              <FallbackCustomPoolFields
-                pool={pool}
-                idPrefix={`custom-pool-${index}`}
-                onChange={(nextPool) => onChangeSelectedPool(index, nextPool)}
-              />
-            )}
-          </div>
-        );
-      })}
-
-      {unselectedPools.map((pool) => {
-        const isDisabled = pool.badge === 'coming-soon';
-        return (
-          <button
-            key={pool.id}
-            type="button"
-            onClick={() => !isDisabled && onTogglePool(pool)}
-            disabled={isDisabled}
-            aria-pressed="false"
-            className={`group w-full p-5 rounded-xl border transition-all text-left relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-              isDisabled
-                ? 'border-border opacity-50 cursor-not-allowed bg-card'
-                : 'border-border bg-card hover:border-primary/45 hover:bg-primary/[0.02]'
-            }`}
-          >
-            {pool.badge && (
-              <div className="absolute top-4 right-4">
-                <span className={`text-xs font-medium uppercase tracking-wider px-2 py-0.5 rounded-full ${
-                  pool.badge === 'testing'
-                    ? 'bg-warning/10 text-warning'
-                    : 'bg-muted text-muted-foreground'
-                }`}>
-                  {pool.badge === 'testing' ? 'Testing' : 'Coming Soon'}
-                </span>
-              </div>
-            )}
-            <div className="flex items-start gap-4">
-              <PoolIcon
-                logoUrl={pool.logoUrl}
-                logoOnDark={pool.logoOnDark}
-                monogram={pool.monogram}
-                invertLogoInDarkMode={pool.invertLogoInDarkMode}
-                logoScale={pool.logoScale}
-                name={pool.name}
-              />
-              <div className="flex-1 min-w-0 pr-8">
-                <div className="font-medium text-sm mb-1">{pool.name}</div>
-                {pool.address && (
-                  <div className="text-xs text-muted-foreground font-mono">{pool.address}:{pool.port}</div>
-                )}
-              </div>
-            </div>
-          </button>
-        );
-      })}
-
-      {selectedCustomIndex === -1 && (
-        <button
-          type="button"
-          onClick={onToggleCustom}
-          aria-pressed="false"
-          className="group w-full p-5 rounded-xl border border-border bg-card transition-all text-left relative hover:border-primary/45 hover:bg-primary/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        >
-          <div className="pr-8">
-            <div className="font-medium text-sm">Custom Pool</div>
-          </div>
-        </button>
-      )}
-    </div>
-  );
-}
-
-function FallbackCustomPoolFields({
-  pool,
-  idPrefix,
-  onChange,
-}: {
-  pool: PoolConfig;
-  idPrefix: string;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  const updateField = (field: keyof PoolConfig, value: string | number) => {
-    const normalized =
-      field === 'authority_public_key' && typeof value === 'string'
-        ? stripWrappingQuotes(value)
-        : value;
-    onChange({ ...pool, [field]: normalized });
-  };
-  const pubkeyError = getPoolAuthorityPubkeyError(pool.authority_public_key);
-
-  return (
-    <div className="border-t border-border bg-muted/20 p-3">
-      <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_7rem_minmax(0,1.4fr)]">
-        <div>
-          <label htmlFor={`${idPrefix}-address`} className="mb-1 block text-xs font-medium text-muted-foreground">
-            Address
-          </label>
-          <input
-            id={`${idPrefix}-address`}
-            type="text"
-            value={pool.address}
-            onChange={(event) => updateField('address', event.target.value)}
-            placeholder="pool.example.com"
-            aria-required="true"
-            autoComplete="off"
-            className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-          />
-        </div>
-
-        <div>
-          <label htmlFor={`${idPrefix}-port`} className="mb-1 block text-xs font-medium text-muted-foreground">
-            Port
-          </label>
-          <input
-            id={`${idPrefix}-port`}
-            type="number"
-            value={pool.port}
-            onChange={(event) => updateField('port', parseInt(event.target.value, 10) || DEFAULT_POOL_PORT)}
-            aria-required="true"
-            className="h-9 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-all focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-          />
-        </div>
-
-        <div>
-          <label htmlFor={`${idPrefix}-pubkey`} className="mb-1 block text-xs font-medium text-muted-foreground">
-            Authority Public Key
-          </label>
-          <input
-            id={`${idPrefix}-pubkey`}
-            type="text"
-            value={pool.authority_public_key}
-            onChange={(event) => updateField('authority_public_key', event.target.value)}
-            placeholder="Pool authority public key"
-            aria-required="true"
-            autoComplete="off"
-            className={`h-9 w-full rounded-lg border bg-background px-3 font-mono text-sm outline-none transition-all focus-visible:ring-2 focus-visible:ring-primary/15 ${
-              pubkeyError ? 'border-destructive focus-visible:border-destructive' : 'border-input focus-visible:border-primary'
-            }`}
-          />
-          {pubkeyError && <p className="mt-1 text-xs text-destructive">{pubkeyError}</p>}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function PoolIdentityFields({
-  pool,
-  miningMode,
-  network,
-  idPrefix,
-  onChange,
-}: {
-  pool: PoolConfig;
-  miningMode: PoolConfigStepProps['data']['miningMode'];
-  network: BitcoinNetwork;
-  idPrefix: string;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  if (miningMode === 'solo' && isSriPool(pool)) {
-    return (
-      <SriPoolIdentityFields
-        pool={pool}
-        network={network}
-        idPrefix={idPrefix}
-        onChange={onChange}
-      />
-    );
-  }
-
-  const label = getIdentityFieldLabel(miningMode);
-  const placeholder = miningMode === 'solo' ? getBitcoinAddressPlaceholder(network) : 'username.worker1';
-  const error = getPoolIdentityError(pool, miningMode, network);
-  const showBraiinsUsernameWarning = miningMode !== 'solo' && shouldAggregateTranslatorChannels(pool);
-
-  return (
-    <div>
-      <label htmlFor={`${idPrefix}-identity`} className="block text-sm font-medium mb-2">
-        {label} <span className="text-primary" aria-hidden="true">*</span>
-        <span className="sr-only">(required)</span>
-      </label>
-      {showBraiinsUsernameWarning && (
-        <div className="mb-3 flex gap-3 rounded-xl bg-warning/[0.08] p-4 text-sm text-warning" role="alert">
-          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
-          <p>
-            Use the exact username from your Braiins Pool account. If this value does not match an existing
-            Braiins account, the pool connection will not be established properly.
-          </p>
-        </div>
-      )}
-      <input
-        id={`${idPrefix}-identity`}
-        type="text"
-        value={pool.user_identity}
-        onChange={(e) => onChange({ ...pool, user_identity: e.target.value })}
-        placeholder={placeholder}
-        aria-required="true"
-        autoComplete="off"
-        className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
-      />
-      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
-      <p className="text-xs text-muted-foreground mt-2">
-        {miningMode === 'solo'
-          ? 'Bitcoin address used by the pool for solo mining payouts.'
-          : 'Pool account username sent to this upstream'}
-      </p>
-    </div>
-  );
-}
-
-function SriPoolIdentityFields({
-  pool,
-  network,
-  idPrefix,
-  onChange,
-}: {
-  pool: PoolConfig;
-  network: BitcoinNetwork;
-  idPrefix: string;
-  onChange: (pool: PoolConfig) => void;
-}) {
-  const parsed = parseSriIdentity(pool.user_identity);
-  const needsAddress = parsed.donationPercent < 100;
-  const identityError = getPoolIdentityError(pool, 'solo', network);
-
-  useEffect(() => {
-    const normalizedPool = normalizePoolUserIdentity(pool, 'solo');
-    if (normalizedPool !== pool) {
-      onChange(normalizedPool);
-    }
-  }, [onChange, pool]);
-
-  const updateSriIdentity = (address: string, workerName: string, donationPercent: number) => {
-    onChange({
-      ...pool,
-      user_identity: buildSriIdentity(address, workerName, donationPercent),
-    });
-  };
-
-  return (
-    <div className="space-y-4">
-      {needsAddress && (
-        <div>
-          <label htmlFor={`${idPrefix}-payout-address`} className="block text-sm font-medium mb-2">
-            Bitcoin payout address <span className="text-primary" aria-hidden="true">*</span>
-            <span className="sr-only">(required)</span>
-          </label>
-          <input
-            id={`${idPrefix}-payout-address`}
-            type="text"
-            value={parsed.address}
-            onChange={(e) => updateSriIdentity(e.target.value, parsed.workerName, parsed.donationPercent)}
-            placeholder={getBitcoinAddressPlaceholder(network)}
-            aria-required="true"
-            autoComplete="off"
-            className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
-          />
-          {getBitcoinAddressError(parsed.address, network) && (
-            <p className="text-xs text-destructive mt-1">{getBitcoinAddressError(parsed.address, network)}</p>
-          )}
-          <p className="text-xs text-muted-foreground mt-2">
-            Used with worker and donation settings to build this pool identity.
-          </p>
-        </div>
-      )}
-
-      <div>
-        <label htmlFor={`${idPrefix}-worker-name`} className="block text-sm font-medium mb-2">
-          Worker Name <span className="text-muted-foreground text-xs font-normal">(optional)</span>
-        </label>
-        <input
-          id={`${idPrefix}-worker-name`}
-          type="text"
-          value={parsed.workerName}
-          onChange={(e) => updateSriIdentity(parsed.address, e.target.value, parsed.donationPercent)}
-          placeholder="worker1"
-          autoComplete="off"
-          className="w-full h-10 px-3 rounded-lg border border-input bg-background focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all font-mono text-sm"
-        />
-      </div>
-
-      <div>
-        <label htmlFor={`${idPrefix}-donation-slider`} className="block text-sm font-medium mb-2">
-          Donation to SRI Development <span className="text-muted-foreground text-xs font-normal">(optional)</span>
-        </label>
-        <div className="p-4 rounded-xl bg-muted/40 space-y-3">
-          <input
-            id={`${idPrefix}-donation-slider`}
-            type="range"
-            min={0}
-            max={100}
-            value={parsed.donationPercent}
-            onChange={(e) => updateSriIdentity(parsed.address, parsed.workerName, snapDonation(Number(e.target.value)))}
-            aria-label={`Donation: ${parsed.donationPercent}%`}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={parsed.donationPercent}
-            className="w-full accent-primary"
-            list={`${idPrefix}-donation-snap-points`}
-          />
-          <datalist id={`${idPrefix}-donation-snap-points`}>
-            <option value="0" />
-            <option value="10" />
-            <option value="25" />
-            <option value="50" />
-            <option value="75" />
-            <option value="100" />
-          </datalist>
-          <div className="flex justify-between text-xs text-muted-foreground select-none">
-            <span>0%</span><span>25%</span><span>50%</span><span>75%</span><span>100%</span>
-          </div>
-        </div>
-        <p className="text-xs text-muted-foreground mt-2">
-          {parsed.donationPercent === 0
-            ? 'Full block reward goes to your payout address'
-            : parsed.donationPercent >= 100
-              ? 'Full block reward is donated to SRI development'
-              : `${parsed.donationPercent}% of the block reward goes to SRI development, ${100 - parsed.donationPercent}% to your address`}
-        </p>
-      </div>
-
-      {identityError && <p className="text-xs text-destructive">{identityError}</p>}
     </div>
   );
 }

--- a/src/lib/miningIdentity.test.ts
+++ b/src/lib/miningIdentity.test.ts
@@ -1,9 +1,30 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { getSriIdentityError, getSriIdentitySummary, normalizeSriIdentity } from './miningIdentity';
+import type { PoolConfig } from '@sv2-ui/shared';
+import {
+  SRI_POOL_AUTHORITY_KEY,
+  getCompatiblePoolIdentity,
+  getSriIdentityError,
+  getSriIdentitySummary,
+  normalizePoolPriorityIdentities,
+  normalizeSriIdentity,
+} from './miningIdentity';
 
 const MAINNET_ADDRESS = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
+const STANDARD_POOL: PoolConfig = {
+  name: 'Standard Pool',
+  address: 'pool.example.com',
+  port: 3333,
+  authority_public_key: 'standard-key',
+  user_identity: MAINNET_ADDRESS,
+};
+const SRI_POOL: PoolConfig = {
+  ...STANDARD_POOL,
+  name: 'SRI Pool',
+  authority_public_key: SRI_POOL_AUTHORITY_KEY,
+  user_identity: `sri/solo/${MAINNET_ADDRESS}/worker1`,
+};
 
 test('getSriIdentityError accepts a valid solo identity', () => {
   assert.equal(getSriIdentityError(`sri/solo/${MAINNET_ADDRESS}/worker1`, 'mainnet'), null);
@@ -43,4 +64,41 @@ test('getSriIdentitySummary avoids exposing internal identity syntax', () => {
     `${MAINNET_ADDRESS}, worker worker1, 0% donation`,
   );
   assert.equal(getSriIdentitySummary('sri/donate'), 'Full reward donated, 100% donation');
+});
+
+test('getCompatiblePoolIdentity converts between standard and SRI solo identity formats', () => {
+  assert.equal(
+    getCompatiblePoolIdentity(SRI_POOL, STANDARD_POOL, 'solo'),
+    MAINNET_ADDRESS,
+  );
+  assert.equal(
+    getCompatiblePoolIdentity(STANDARD_POOL, SRI_POOL, 'solo'),
+    `sri/solo/${MAINNET_ADDRESS}`,
+  );
+});
+
+test('getCompatiblePoolIdentity does not leak a full-donation identity to another solo pool', () => {
+  assert.equal(
+    getCompatiblePoolIdentity({ ...SRI_POOL, user_identity: 'sri/donate' }, STANDARD_POOL, 'solo'),
+    '',
+  );
+});
+
+test('normalizePoolPriorityIdentities updates inherited fallback identities but preserves overrides', () => {
+  const nextPrimary = { ...STANDARD_POOL, user_identity: 'new-primary.worker' };
+  const inheritedFallback = { ...STANDARD_POOL, address: 'fallback.example.com' };
+  const customFallback = {
+    ...STANDARD_POOL,
+    address: 'custom-fallback.example.com',
+    user_identity: 'custom.worker',
+  };
+
+  const result = normalizePoolPriorityIdentities(
+    [nextPrimary, inheritedFallback, customFallback],
+    STANDARD_POOL,
+    'pool',
+  );
+
+  assert.equal(result[1].user_identity, 'new-primary.worker');
+  assert.equal(result[2].user_identity, 'custom.worker');
 });

--- a/src/lib/miningIdentity.test.ts
+++ b/src/lib/miningIdentity.test.ts
@@ -102,3 +102,27 @@ test('normalizePoolPriorityIdentities updates inherited fallback identities but 
   assert.equal(result[1].user_identity, 'new-primary.worker');
   assert.equal(result[2].user_identity, 'custom.worker');
 });
+
+test('normalizePoolPriorityIdentities preserves fallback payout addresses during full donation', () => {
+  const previousPrimary = {
+    ...SRI_POOL,
+    user_identity: `sri/donate/25/${MAINNET_ADDRESS}/worker1`,
+  };
+  const nextPrimary = {
+    ...SRI_POOL,
+    user_identity: 'sri/donate/worker1',
+  };
+  const fallback = {
+    ...STANDARD_POOL,
+    address: 'fallback.example.com',
+    user_identity: MAINNET_ADDRESS,
+  };
+
+  const result = normalizePoolPriorityIdentities(
+    [nextPrimary, fallback],
+    previousPrimary,
+    'solo',
+  );
+
+  assert.equal(result[1].user_identity, MAINNET_ADDRESS);
+});

--- a/src/lib/miningIdentity.ts
+++ b/src/lib/miningIdentity.ts
@@ -84,6 +84,70 @@ export function normalizePoolUserIdentity(pool: PoolConfig, miningMode: MiningMo
     : { ...pool, user_identity: normalizedIdentity };
 }
 
+/**
+ * Convert an existing pool identity into the representation expected by a
+ * target pool. SRI solo pools use a structured identity while other solo
+ * pools use a plain payout address.
+ */
+export function getCompatiblePoolIdentity(
+  sourcePool: PoolConfig | null | undefined,
+  targetPool: PoolConfig,
+  miningMode: MiningMode | null,
+): string {
+  const sourceIdentity = sourcePool?.user_identity ?? '';
+  if (!sourceIdentity) return '';
+
+  if (miningMode === 'solo' && isSriPool(sourcePool) && !isSriPool(targetPool)) {
+    const parsed = parseSriIdentity(sourceIdentity);
+    return parsed.donationPercent >= 100 ? '' : parsed.address;
+  }
+
+  return normalizePoolUserIdentity(
+    { ...targetPool, user_identity: sourceIdentity },
+    miningMode,
+  ).user_identity;
+}
+
+export function withCompatiblePoolIdentity(
+  sourcePool: PoolConfig | null | undefined,
+  targetPool: PoolConfig,
+  miningMode: MiningMode | null,
+): PoolConfig {
+  return {
+    ...targetPool,
+    user_identity: getCompatiblePoolIdentity(sourcePool, targetPool, miningMode),
+  };
+}
+
+/**
+ * Normalize an ordered pool list while keeping fallback identities in sync
+ * with the primary identity unless the user customized them explicitly.
+ */
+export function normalizePoolPriorityIdentities(
+  nextPools: PoolConfig[],
+  previousPrimaryPool: PoolConfig | null | undefined,
+  miningMode: MiningMode | null,
+): PoolConfig[] {
+  const normalizedPools = nextPools.map((pool) => normalizePoolUserIdentity(pool, miningMode));
+  const nextPrimaryPool = normalizedPools[0] ?? null;
+
+  return normalizedPools.map((pool, index) => {
+    if (index === 0) return pool;
+
+    const previousDefaultIdentity = getCompatiblePoolIdentity(
+      previousPrimaryPool,
+      pool,
+      miningMode,
+    );
+
+    if (pool.user_identity && pool.user_identity !== previousDefaultIdentity) {
+      return pool;
+    }
+
+    return withCompatiblePoolIdentity(nextPrimaryPool, pool, miningMode);
+  });
+}
+
 export function getSriIdentitySummary(identity: string): string {
   if (!identity) return 'Username not set';
 

--- a/src/lib/miningIdentity.ts
+++ b/src/lib/miningIdentity.ts
@@ -139,12 +139,24 @@ export function normalizePoolPriorityIdentities(
       pool,
       miningMode,
     );
+    const nextDefaultIdentity = getCompatiblePoolIdentity(
+      nextPrimaryPool,
+      pool,
+      miningMode,
+    );
 
     if (pool.user_identity && pool.user_identity !== previousDefaultIdentity) {
       return pool;
     }
 
-    return withCompatiblePoolIdentity(nextPrimaryPool, pool, miningMode);
+    // A full-donation SRI identity intentionally contains no payout address.
+    // Keep an inherited fallback address instead of erasing information that
+    // cannot be represented in the primary pool's protocol identity.
+    if (!nextDefaultIdentity && pool.user_identity) {
+      return pool;
+    }
+
+    return { ...pool, user_identity: nextDefaultIdentity };
   });
 }
 

--- a/src/lib/poolValidation.ts
+++ b/src/lib/poolValidation.ts
@@ -1,0 +1,24 @@
+import type { BitcoinNetwork, MiningMode, PoolConfig } from '@sv2-ui/shared';
+import { getPoolIdentityError } from './miningIdentity';
+import { isValidPoolAuthorityPubkey } from './utils';
+
+export function isPoolConnectionComplete(pool: PoolConfig | null | undefined): boolean {
+  return Boolean(
+    pool?.address &&
+    Number.isInteger(pool.port) &&
+    pool.port > 0 &&
+    pool.port <= 65535 &&
+    isValidPoolAuthorityPubkey(pool.authority_public_key),
+  );
+}
+
+export function isPoolComplete(
+  pool: PoolConfig | null | undefined,
+  miningMode: MiningMode | null,
+  network: BitcoinNetwork,
+): boolean {
+  return Boolean(
+    isPoolConnectionComplete(pool) &&
+    !getPoolIdentityError(pool, miningMode, network),
+  );
+}


### PR DESCRIPTION
This PR replaced the three separate custom-pool workflows from PR #217 with one shared pool configuration flow used by both Setup and Settings. Users can now add, remove, and reorder primary and fallback pools in the same interface. The primary payout address or username is entered once, while fallback pools inherit it automatically unless the user explicitly chooses to customize them.

This is better because there is now one consistent behavior to understand, test, and maintain instead of several implementations that could drift apart. It also reduces repetitive forms and excessive scrolling, preserves custom fallback identities safely, and validates pool configuration on both the client and server before saving.

I based it on #217 to preserve commit history and credit the author for the effort that inspired a more complex refactor. There's a lot here so no need to prio review, but whenever you get a chance @lucasbalieiro I'd appreciate if you have a better idea on how to architect this.

https://github.com/user-attachments/assets/153e76dd-4922-4c94-8277-f08d8431d7d5