### PR TITLE
Expose `min_individual_worker` hashrate config in settings

### DIFF
--- a/server/src/config-generator.test.ts
+++ b/server/src/config-generator.test.ts
@@ -70,6 +70,7 @@ const NO_JD_DATA: SetupData = {
 test('translator config uses advanced setup values', () => {
   const config = generateTranslatorConfig(BASE_DATA_30);
 
+  assert.match(config, /min_individual_miner_hashrate = 100000000000000\.0/);
   assert.match(config, /downstream_extranonce2_size = 8/);
   assert.match(config, /shares_per_minute = 12\.5/);
 });
@@ -157,6 +158,7 @@ test('normalization backfills advanced defaults for old saved configs', () => {
     ...BASE_DATA_30,
     translator: {
       ...BASE_DATA_30.translator,
+      min_hashrate: undefined,
       shares_per_minute: undefined,
       downstream_extranonce2_size: undefined,
     },
@@ -165,6 +167,7 @@ test('normalization backfills advanced defaults for old saved configs', () => {
   const normalized = normalizeSetupData(data);
 
   assert.ok(normalized.translator);
+  assert.equal(normalized.translator.min_hashrate, 100_000_000_000_000);
   assert.equal(normalized.translator.shares_per_minute, 6);
   assert.equal(normalized.translator.downstream_extranonce2_size, 4);
   assert.equal('verify_payout' in normalized.translator, false);

--- a/server/src/config-generator.ts
+++ b/server/src/config-generator.ts
@@ -11,6 +11,7 @@ import {
   isFullDonationIdentity,
   DEFAULT_SHARES_PER_MINUTE,
   DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE,
+  DEFAULT_MIN_HASHRATE,
   bitcoinCoreVersionToIpcMajor,
   formatSupportedVersions,
 } from '@sv2-ui/shared';
@@ -137,7 +138,7 @@ export function normalizeSetupData(data: SetupData): SetupData {
       enable_vardiff: data.translator.enable_vardiff,
       aggregate_channels: shouldAggregateTranslatorChannelsForPools([pool, ...fallbackPools]),
       ...(isSoloPool ? { verify_payout: data.translator.verify_payout ?? true } : {}),
-      min_hashrate: data.translator.min_hashrate,
+      min_hashrate: positiveNumber(data.translator.min_hashrate, DEFAULT_MIN_HASHRATE),
       shares_per_minute: positiveNumber(data.translator.shares_per_minute, DEFAULT_SHARES_PER_MINUTE),
       downstream_extranonce2_size: positiveInteger(
         data.translator.downstream_extranonce2_size,
@@ -173,7 +174,7 @@ verify_payout = ${verifyPayout}
     : '';
 
   // Min hashrate from user config (default 100 TH/s if not set)
-  const minHashrate = translator.min_hashrate ? `${translator.min_hashrate}.0` : '100_000_000_000_000.0';
+  const minHashrate = `${positiveNumber(translator.min_hashrate, DEFAULT_MIN_HASHRATE)}.0`;
   // Shares per minute target
   const sharesPerMinute = positiveNumber(translator.shares_per_minute, DEFAULT_SHARES_PER_MINUTE).toFixed(1);
   const downstreamExtranonce2Size = positiveInteger(

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -39,6 +39,7 @@ export const JDC_MONITORING_PORT = 9091;
 
 export const DEFAULT_SHARES_PER_MINUTE = 6;
 export const DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE = 4;
+export const DEFAULT_MIN_HASHRATE = 100_000_000_000_000;
 export const DEFAULT_POOL_PORT = 34254;
 
 export function computeDefaultSocketPath(dataDir: string, network: BitcoinNetwork): string {

--- a/src/components/settings/ConfigurationTab.tsx
+++ b/src/components/settings/ConfigurationTab.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { PoolIcon } from '@/components/ui/pool-icon';
+import { HashrateInput } from '@/components/ui/hashrate-input';
 import { useSetupStatus } from '@/hooks/useSetupStatus';
 import { useControlApi, getCurrentConfig } from '@/hooks/useControlApi';
 import {
@@ -29,6 +30,7 @@ import {
   getBitcoinAddressPlaceholder,
   getIdentifierError,
   getPoolAuthorityPubkeyError,
+  formatHashrate,
   isValidPoolAuthorityPubkey,
   isTomlSafeIdentifier,
   stripWrappingQuotes,
@@ -38,6 +40,7 @@ import type { PoolConfig, SetupData } from '@/components/setup/types';
 import {
   DEFAULT_SHARES_PER_MINUTE,
   DEFAULT_DOWNSTREAM_EXTRANONCE2_SIZE,
+  DEFAULT_MIN_HASHRATE,
   DEFAULT_POOL_PORT,
   formatBitcoinCoreVersion,
   normalizeBitcoinCoreVersion,
@@ -84,7 +87,7 @@ const SETUP_TARGET_STEP_STORAGE_KEY = 'sv2-ui-setup-target-step';
 const DONATION_SNAP_POINTS = [0, 10, 25, 50, 75, 100];
 const DONATION_SNAP_THRESHOLD = 3;
 
-type EditingField = null | 'pool' | 'fallbackPools' | 'mode' | 'signature' | 'advanced';
+type EditingField = null | 'pool' | 'fallbackPools' | 'mode' | 'signature' | 'hashrate' | 'advanced';
 
 function snapDonation(value: number): number {
   const nearest = DONATION_SNAP_POINTS.find((p) => Math.abs(value - p) <= DONATION_SNAP_THRESHOLD);
@@ -135,6 +138,8 @@ export function ConfigurationTab() {
   const [isCustomPool, setIsCustomPool] = useState(false);
   const [editMode, setEditMode] = useState<'jd' | 'no-jd' | null>(null);
   const [editSignature, setEditSignature] = useState<string>('');
+  const [editHashrate, setEditHashrate] = useState<number | null>(null);
+  const [hashrateInputValid, setHashrateInputValid] = useState(true);
   const [editAdvanced, setEditAdvanced] = useState<{
     shares_per_minute: string;
     downstream_extranonce2_size: string;
@@ -237,6 +242,13 @@ export function ConfigurationTab() {
     setEditing('signature');
   };
 
+  const startEditHashrate = () => {
+    if (!config?.translator) return;
+    setEditHashrate(config.translator.min_hashrate || DEFAULT_MIN_HASHRATE);
+    setHashrateInputValid(true);
+    setEditing('hashrate');
+  };
+
   const startEditAdvanced = () => {
     if (!config?.translator) return;
     const configIsSoloPool = config.miningMode === 'solo' && config.mode === 'no-jd';
@@ -257,6 +269,8 @@ export function ConfigurationTab() {
     setIsCustomPool(false);
     setEditMode(null);
     setEditSignature('');
+    setEditHashrate(null);
+    setHashrateInputValid(true);
     setEditAdvanced(null);
   };
 
@@ -279,6 +293,11 @@ export function ConfigurationTab() {
     !getPoolIdentityError(pool, config?.miningMode ?? null, editNetwork)
   ));
   const isSignatureValid = editSignature === '' || isTomlSafeIdentifier(editSignature);
+  const isHashrateValid =
+    hashrateInputValid &&
+    editHashrate !== null &&
+    Number.isFinite(editHashrate) &&
+    editHashrate > 0;
   const isAdvancedValid =
     !!editAdvanced &&
     isPositiveNumber(editAdvanced.shares_per_minute) &&
@@ -308,6 +327,12 @@ export function ConfigurationTab() {
     } else if (editing === 'signature') {
       if (!isSignatureValid || !config.jdc) return;
       updated.jdc = { ...config.jdc, jdc_signature: editSignature.trim() };
+    } else if (editing === 'hashrate') {
+      if (!isHashrateValid || !config.translator || editHashrate === null) return;
+      updated.translator = {
+        ...config.translator,
+        min_hashrate: editHashrate,
+      };
     } else if (editing === 'advanced') {
       if (!isAdvancedValid || !config.translator || !editAdvanced) return;
       const configIsSoloPool = config.miningMode === 'solo' && config.mode === 'no-jd';
@@ -786,6 +811,40 @@ export function ConfigurationTab() {
                     Miner-chosen tag shown in coinbase transactions on block explorers.
                   </p>
                 </div>
+              }
+            />
+          )}
+
+          {/* Lowest worker hashrate */}
+          {config.translator && (
+            <ConfigRow
+              label="Lowest Worker Hashrate"
+              editing={editing === 'hashrate'}
+              onEdit={startEditHashrate}
+              onSave={saveEdit}
+              onCancel={cancelEdit}
+              isSaving={isSaving}
+              saveDisabled={!isHashrateValid}
+              disabled={editing !== null && editing !== 'hashrate'}
+              display={
+                <p className="text-sm text-muted-foreground">
+                  {formatHashrate(config.translator.min_hashrate || DEFAULT_MIN_HASHRATE)}
+                </p>
+              }
+              editContent={
+                editHashrate !== null && (
+                  <div className="space-y-3">
+                    <p className="text-xs text-muted-foreground">
+                      One worker? Enter its hashrate. Multiple? Use the lowest performing.
+                    </p>
+                    <HashrateInput
+                      idPrefix="edit-lowest-worker-hashrate"
+                      value={editHashrate}
+                      onChange={setEditHashrate}
+                      onValidityChange={setHashrateInputValid}
+                    />
+                  </div>
+                )
               }
             />
           )}

--- a/src/components/setup/steps/HashrateStep.tsx
+++ b/src/components/setup/steps/HashrateStep.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import { StepProps } from '../types';
 import { Check, ChevronDown, Settings2 } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
+import { HashrateInput } from '@/components/ui/hashrate-input';
+import { formatHashrate } from '@/lib/utils';
+import { DEFAULT_MIN_HASHRATE } from '@sv2-ui/shared';
 
 interface HashratePreset {
   id: string;
@@ -12,7 +15,7 @@ interface HashratePreset {
 
 const HASHRATE_PRESETS: HashratePreset[] = [
   { id: 'bitaxe',      label: 'Bitaxe / USB Miner', hashrate: 500_000_000_000,     description: '~500 GH/s' },
-  { id: 'mid-asic',    label: 'Mid-Range ASIC',       hashrate: 100_000_000_000_000, description: '~100 TH/s' },
+  { id: 'mid-asic',    label: 'Mid-Range ASIC',       hashrate: DEFAULT_MIN_HASHRATE, description: '~100 TH/s' },
   { id: 'high-asic',   label: 'High-End ASIC',        hashrate: 300_000_000_000_000, description: '~300 TH/s' },
   { id: 'custom',      label: 'Custom',               hashrate: 0,                   description: 'Enter your own value' },
 ];
@@ -30,14 +33,6 @@ function isPositiveInteger(value: string): boolean {
   return isPositiveNumber(value) && Number.isInteger(parsed);
 }
 
-function formatHashrateDisplay(hashrate: number): string {
-  if (hashrate >= 1e15) return `${(hashrate / 1e15).toFixed(2)} PH/s`;
-  if (hashrate >= 1e12) return `${(hashrate / 1e12).toFixed(2)} TH/s`;
-  if (hashrate >= 1e9)  return `${(hashrate / 1e9).toFixed(2)} GH/s`;
-  if (hashrate >= 1e6)  return `${(hashrate / 1e6).toFixed(2)} MH/s`;
-  return `${hashrate.toLocaleString()} H/s`;
-}
-
 export function HashrateStep({ data, updateData, onNext }: StepProps) {
   const isSoloPool = data.miningMode === 'solo' && data.mode === 'no-jd';
   const existingHashrate = data.translator?.min_hashrate || 0;
@@ -50,30 +45,9 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
     return HASHRATE_PRESETS.find(p => p.hashrate === existingHashrate)?.id || 'custom';
   };
 
-  const SLIDER_MIN = 9;
-  const SLIDER_MAX = 16;
-  const SLIDER_STEPS = 1000;
-
-  const rawToSlider = (hr: number) =>
-    Math.round(((Math.log10(Math.max(hr, 1e9)) - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * SLIDER_STEPS);
-  const sliderToRaw = (s: number) =>
-    Math.round(Math.pow(10, SLIDER_MIN + (s / SLIDER_STEPS) * (SLIDER_MAX - SLIDER_MIN)));
-
-  const getAutoUnit = (hr: number): { label: string; multiplier: number } => {
-    if (hr >= 1e15) return { label: 'PH/s', multiplier: 1e15 };
-    if (hr >= 1e12) return { label: 'TH/s', multiplier: 1e12 };
-    if (hr >= 1e9)  return { label: 'GH/s', multiplier: 1e9  };
-    return { label: 'MH/s', multiplier: 1e6 };
-  };
-
   const [selectedPreset, setSelectedPreset] = useState(getInitialPreset());
-  const [rawHashrate, setRawHashrate] = useState(existingHashrate > 0 ? existingHashrate : 100_000_000_000_000);
-  const [customInputValue, setCustomInputValue] = useState(() => {
-    const initial = existingHashrate > 0 ? existingHashrate : 100_000_000_000_000;
-    const { multiplier } = getAutoUnit(initial);
-    return (initial / multiplier).toPrecision(6).replace(/\.?0+$/, '');
-  });
-  const [inputError, setInputError] = useState<string | null>(null);
+  const [rawHashrate, setRawHashrate] = useState(existingHashrate > 0 ? existingHashrate : DEFAULT_MIN_HASHRATE);
+  const [hashrateInputValid, setHashrateInputValid] = useState(true);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [verifyPayout, setVerifyPayout] = useState(data.translator?.verify_payout ?? true);
   const [sharesPerMinute, setSharesPerMinute] = useState(String(existingSharesPerMinute));
@@ -81,47 +55,17 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
     String(existingDownstreamExtranonce2Size),
   );
 
-  const syncCustomInputToRaw = (raw: number) => {
-    const { multiplier } = getAutoUnit(raw);
-    setCustomInputValue((raw / multiplier).toPrecision(6).replace(/\.?0+$/, ''));
-  };
-
   const handlePresetChange = (presetId: string) => {
     setSelectedPreset(presetId);
     if (presetId !== 'custom') {
       const preset = HASHRATE_PRESETS.find(p => p.id === presetId);
       if (preset) {
         setRawHashrate(preset.hashrate);
-        syncCustomInputToRaw(preset.hashrate);
       }
     }
   };
 
-  const handleSliderChange = (value: number) => {
-    const raw = sliderToRaw(value);
-    setRawHashrate(raw);
-    syncCustomInputToRaw(raw);
-  };
-
-  const handleInputChange = (value: string) => {
-    const cleaned = value.replace(/e/i, '');
-    setCustomInputValue(cleaned);
-
-    const numValue = Number(cleaned);
-    if (cleaned === '' || isNaN(numValue) || numValue < 0) {
-      setInputError(cleaned === '' ? 'Required' : 'Invalid hashrate');
-    } else {
-      setInputError(null);
-      const unit = getAutoUnit(rawHashrate);
-      const newRaw = Math.round(numValue * unit.multiplier);
-      setRawHashrate(newRaw);
-    }
-  };
-
-  const getHashrateValue = () =>
-    selectedPreset === 'custom' ? rawHashrate : (HASHRATE_PRESETS.find(p => p.id === selectedPreset)?.hashrate || 0);
-
-  const hashrate = getHashrateValue();
+  const hashrate = rawHashrate;
   const advancedIsValid =
     isPositiveNumber(sharesPerMinute) &&
     isPositiveInteger(downstreamExtranonce2Size);
@@ -184,47 +128,17 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
         })}
       </div>
 
-      {selectedPreset === 'custom' && (() => {
-        const { label } = getAutoUnit(rawHashrate);
-        return (
-          <div className="p-4 rounded-xl bg-muted/40 space-y-3">
-            <div className="flex items-center gap-2">
-              <label htmlFor="custom-hashrate" className="sr-only">Hashrate value in {label}</label>
-              <input
-                id="custom-hashrate"
-                type="number"
-                min="0"
-                value={customInputValue}
-                onChange={(e) => handleInputChange(e.target.value)}
-                aria-describedby="hashrate-unit hashrare-error"
-                className="flex-1 h-10 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
-              />
-              <span id="hashrate-unit" className="text-sm font-medium text-muted-foreground w-12 text-right" aria-live="polite">{label}</span>
-            </div>
-            {inputError && (
-              <div id="hashrare-error" className="text-xs text-destructive">{inputError}</div>
-            )}
-            <input
-              type="range"
-              min={0}
-              max={SLIDER_STEPS}
-              value={rawToSlider(rawHashrate)}
-              onChange={(e) => handleSliderChange(Number(e.target.value))}
-              aria-label={`Hashrate: ${formatHashrateDisplay(rawHashrate)}`}
-              aria-valuemin={0}
-              aria-valuemax={SLIDER_STEPS}
-              aria-valuenow={rawToSlider(rawHashrate)}
-              className="w-full accent-primary"
-            />
-            <div className="flex justify-between text-xs text-muted-foreground select-none">
-              <span>1 GH/s</span><span>8 GH/s</span><span>56 GH/s</span><span>420 GH/s</span><span>3 TH/s</span><span>24 TH/s</span><span>180 TH/s</span><span>1 PH/s</span><span>10 PH/s</span>
-            </div>
-          </div>
-        );
-      })()}
+      {selectedPreset === 'custom' && (
+        <HashrateInput
+          idPrefix="custom-hashrate"
+          value={rawHashrate}
+          onChange={setRawHashrate}
+          onValidityChange={setHashrateInputValid}
+        />
+      )}
 
       {hashrate > 0 && (() => {
-        const display = formatHashrateDisplay(hashrate);
+        const display = formatHashrate(hashrate);
         return (
           <div className="p-4 rounded-xl bg-primary/[0.08] text-center">
             <div className="text-sm text-muted-foreground mb-1">Starting difficulty per miner</div>
@@ -319,7 +233,7 @@ export function HashrateStep({ data, updateData, onNext }: StepProps) {
         <button
           type="button"
           onClick={onNext}
-          disabled={hashrate <= 0 || !advancedIsValid}
+          disabled={hashrate <= 0 || (selectedPreset === 'custom' && !hashrateInputValid) || !advancedIsValid}
           className="h-11 px-10 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors font-medium"
         >
           Continue

--- a/src/components/ui/hashrate-input.tsx
+++ b/src/components/ui/hashrate-input.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+
+import { formatHashrate } from '@/lib/utils';
+
+const SLIDER_MIN_EXPONENT = 9;
+const SLIDER_MAX_EXPONENT = 16;
+const SLIDER_STEPS = 1000;
+
+interface HashrateUnit {
+  label: string;
+  multiplier: number;
+}
+
+function getAutoUnit(hashrate: number): HashrateUnit {
+  if (hashrate >= 1e15) return { label: 'PH/s', multiplier: 1e15 };
+  if (hashrate >= 1e12) return { label: 'TH/s', multiplier: 1e12 };
+  if (hashrate >= 1e9) return { label: 'GH/s', multiplier: 1e9 };
+  return { label: 'MH/s', multiplier: 1e6 };
+}
+
+function formatInputValue(hashrate: number): string {
+  const { multiplier } = getAutoUnit(hashrate);
+  return (hashrate / multiplier).toPrecision(6).replace(/\.?0+$/, '');
+}
+
+function rawToSlider(hashrate: number): number {
+  const exponent = Math.log10(Math.max(hashrate, 10 ** SLIDER_MIN_EXPONENT));
+  const position = ((exponent - SLIDER_MIN_EXPONENT) / (SLIDER_MAX_EXPONENT - SLIDER_MIN_EXPONENT))
+    * SLIDER_STEPS;
+  return Math.min(SLIDER_STEPS, Math.max(0, Math.round(position)));
+}
+
+function sliderToRaw(position: number): number {
+  return Math.round(10 ** (
+    SLIDER_MIN_EXPONENT
+    + (position / SLIDER_STEPS) * (SLIDER_MAX_EXPONENT - SLIDER_MIN_EXPONENT)
+  ));
+}
+
+interface HashrateInputProps {
+  value: number;
+  onChange: (value: number) => void;
+  onValidityChange?: (isValid: boolean) => void;
+  idPrefix?: string;
+}
+
+/**
+ * Shared logarithmic hashrate input used by setup and configuration settings.
+ */
+export function HashrateInput({
+  value,
+  onChange,
+  onValidityChange,
+  idPrefix = 'hashrate',
+}: HashrateInputProps) {
+  const [inputValue, setInputValue] = useState(() => formatInputValue(value));
+  const [inputError, setInputError] = useState<string | null>(null);
+  const { label, multiplier } = getAutoUnit(value);
+  const inputId = `${idPrefix}-input`;
+  const unitId = `${idPrefix}-unit`;
+  const errorId = `${idPrefix}-error`;
+
+  useEffect(() => {
+    setInputValue(formatInputValue(value));
+    onValidityChange?.(Number.isFinite(value) && value > 0);
+  }, [onValidityChange, value]);
+
+  const handleInputChange = (nextValue: string) => {
+    const cleaned = nextValue.replace(/e/i, '');
+    setInputValue(cleaned);
+
+    const parsed = Number(cleaned);
+    if (cleaned === '' || !Number.isFinite(parsed) || parsed <= 0) {
+      setInputError(cleaned === '' ? 'Required' : 'Invalid hashrate');
+      onValidityChange?.(false);
+      return;
+    }
+
+    setInputError(null);
+    onValidityChange?.(true);
+    onChange(Math.round(parsed * multiplier));
+  };
+
+  const handleSliderChange = (position: number) => {
+    setInputError(null);
+    onValidityChange?.(true);
+    onChange(sliderToRaw(position));
+  };
+
+  return (
+    <div className="p-4 rounded-xl bg-muted/40 space-y-3">
+      <div className="flex items-center gap-2">
+        <label htmlFor={inputId} className="sr-only">Hashrate value in {label}</label>
+        <input
+          id={inputId}
+          type="number"
+          min="0"
+          value={inputValue}
+          onChange={(event) => handleInputChange(event.target.value)}
+          aria-describedby={`${unitId}${inputError ? ` ${errorId}` : ''}`}
+          aria-invalid={inputError ? true : undefined}
+          className="flex-1 h-10 min-w-0 px-3 rounded-lg border border-input bg-background text-sm focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15 outline-none transition-all"
+        />
+        <span
+          id={unitId}
+          className="text-sm font-medium text-muted-foreground w-12 text-right"
+          aria-live="polite"
+        >
+          {label}
+        </span>
+      </div>
+      {inputError && <div id={errorId} className="text-xs text-destructive">{inputError}</div>}
+      <input
+        type="range"
+        min={0}
+        max={SLIDER_STEPS}
+        value={rawToSlider(value)}
+        onChange={(event) => handleSliderChange(Number(event.target.value))}
+        aria-label={`Hashrate: ${formatHashrate(value)}`}
+        aria-valuemin={0}
+        aria-valuemax={SLIDER_STEPS}
+        aria-valuenow={rawToSlider(value)}
+        className="w-full accent-primary"
+      />
+      <div className="flex justify-between text-xs text-muted-foreground select-none" aria-hidden="true">
+        <span>1 GH/s</span><span>8 GH/s</span><span>56 GH/s</span><span>420 GH/s</span><span>3 TH/s</span><span>24 TH/s</span><span>180 TH/s</span><span>1 PH/s</span><span>10 PH/s</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/hashrate-input.tsx
+++ b/src/components/ui/hashrate-input.tsx
@@ -55,15 +55,26 @@ export function HashrateInput({
 }: HashrateInputProps) {
   const [inputValue, setInputValue] = useState(() => formatInputValue(value));
   const [inputError, setInputError] = useState<string | null>(null);
-  const { label, multiplier } = getAutoUnit(value);
+  const [inputUnit, setInputUnit] = useState(() => getAutoUnit(value));
+  const [inputFocused, setInputFocused] = useState(false);
+  const { label, multiplier } = inputUnit;
   const inputId = `${idPrefix}-input`;
   const unitId = `${idPrefix}-unit`;
   const errorId = `${idPrefix}-error`;
 
   useEffect(() => {
-    setInputValue(formatInputValue(value));
-    onValidityChange?.(Number.isFinite(value) && value > 0);
-  }, [onValidityChange, value]);
+    if (inputError) {
+      onValidityChange?.(false);
+      return;
+    }
+
+    const isValid = Number.isFinite(value) && value > 0;
+    if (!inputFocused) {
+      setInputUnit(getAutoUnit(value));
+      setInputValue(formatInputValue(value));
+    }
+    onValidityChange?.(isValid);
+  }, [inputError, inputFocused, onValidityChange, value]);
 
   const handleInputChange = (nextValue: string) => {
     const cleaned = nextValue.replace(/e/i, '');
@@ -81,10 +92,27 @@ export function HashrateInput({
     onChange(Math.round(parsed * multiplier));
   };
 
+  const handleInputBlur = () => {
+    setInputFocused(false);
+
+    const parsed = Number(inputValue);
+    if (inputError || inputValue === '' || !Number.isFinite(parsed) || parsed <= 0) {
+      return;
+    }
+
+    const nextRaw = Math.round(parsed * multiplier);
+    setInputUnit(getAutoUnit(nextRaw));
+    setInputValue(formatInputValue(nextRaw));
+  };
+
   const handleSliderChange = (position: number) => {
+    const raw = sliderToRaw(position);
     setInputError(null);
+    setInputFocused(false);
+    setInputUnit(getAutoUnit(raw));
+    setInputValue(formatInputValue(raw));
     onValidityChange?.(true);
-    onChange(sliderToRaw(position));
+    onChange(raw);
   };
 
   return (
@@ -96,6 +124,8 @@ export function HashrateInput({
           type="number"
           min="0"
           value={inputValue}
+          onFocus={() => setInputFocused(true)}
+          onBlur={handleInputBlur}
           onChange={(event) => handleInputChange(event.target.value)}
           aria-describedby={`${unitId}${inputError ? ` ${errorId}` : ''}`}
           aria-invalid={inputError ? true : undefined}


### PR DESCRIPTION
Yesterday I was in a situation where I had to dynamically adjust lowest worker hashrate to debug an issue with hashrate rental. Since we don't expose this in settings, I had to re-do entire setup from scratch every time I wanted to do that which was quite annoying. 

This PR lets users update the lowest worker hashrate directly from Settings using the same logarithmic slider and unit-aware input found in the setup wizard. The slider is now a shared component to keep both screens visually and functionally consistent, while Settings uses a simplified version without miner presets. It also centralizes the default 100 TH/s value, validates user input, restarts services after saving, and ensures older configurations receive the correct default hashrate.

The 100 TH/s fallback was previously hardcoded in multiple places. This PR defines it once as DEFAULT_MIN_HASHRATE and reuses that constant in the setup UI and server configuration.

<img width="1150" height="862" alt="Screenshot 2026-07-21 at 13 16 24" src="https://github.com/user-attachments/assets/8d7fc82d-ea1a-4bd3-ac4b-b08c2eb7f901" />
