### PR TITLE
feat(ui): improve formatting and readability of downloaded container logs

### DIFF
--- a/src/components/data/ContainerLogsPanel.tsx
+++ b/src/components/data/ContainerLogsPanel.tsx
@@ -10,14 +10,35 @@ interface ContainerLogsPanelProps {
 }
 
 function buildDownloadContent(lines: ContainerLogLine[]): string {
+  // Find the longest container name for padding so columns align perfectly
+  const maxContainerLen = Math.max(...lines.map(l => l.container.length), 10);
+
   return lines
     .map((line) => {
-      const parts: string[] = [];
-      if (line.timestamp) parts.push(line.timestamp);
-      parts.push(`[${line.container}]`);
-      parts.push(`[${line.stream}]`);
-      parts.push(line.message);
-      return parts.join(' ');
+      // Clean up the application's internal timestamp if it exists at the start of the message
+      // (e.g. matching "2026-07-28T11:45:20.166418Z ")
+      let cleanMessage = line.message.trim();
+      const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+/;
+      if (isoDateRegex.test(cleanMessage)) {
+        cleanMessage = cleanMessage.replace(isoDateRegex, '');
+      }
+
+      // Format the docker timestamp to be shorter and cleaner (e.g. YYYY-MM-DD HH:MM:SS)
+      let displayTime = '';
+      if (line.timestamp) {
+        try {
+          const d = new Date(line.timestamp);
+          displayTime = `[${d.toISOString().replace('T', ' ').substring(0, 19)}] `;
+        } catch {
+          displayTime = `[${line.timestamp}] `;
+        }
+      }
+
+      // Pad container name for aligned columns
+      const containerStr = `[${line.container}]`.padEnd(maxContainerLen + 2);
+      const streamStr = line.stream === 'stderr' ? '[err]' : '[out]';
+
+      return `${displayTime}${containerStr} ${streamStr} ${cleanMessage}`;
     })
     .join('\n');
 }


### PR DESCRIPTION
## Summary
I had improves the formatting of downloaded `.txt` container logs from the UI to make them significantly more readable. 

Previously, the downloaded logs contained duplicate ISO timestamps (one from Docker and one from the application itself) and unaligned columns, making them difficult to parse visually.

## Output
**Before:**
`2026-07-28T11:45:20.170626099Z [translator] [stdout] 2026-07-28T11:45:20.166418Z  INFO translator_sv2: Starting Translator Proxy...`

<img width="1919" height="714" alt="image" src="https://github.com/user-attachments/assets/d2c4bf99-ec80-4f54-95a8-e255d38a7c9f" />

**After:**
`[2026-07-28 11:45:20] [translator] [out] INFO translator_sv2: Starting Translator Proxy...`
<img width="1919" height="663" alt="image" src="https://github.com/user-attachments/assets/8e1b5b7a-b8b9-4c90-a1a7-17414a6c3584" />
