### PR TITLE
fix: remove shell injection from socket existence check

### DIFF
--- a/server/src/bitcoin-socket-exists.test.ts
+++ b/server/src/bitcoin-socket-exists.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { bitcoinSocketExistsScript } from './bitcoin-socket-exists.js';
+
+test('bitcoinSocketExistsScript must not execute shell commands embedded in the socket path', () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'sock-inj-'));
+  const marker = path.join(tmp, 'pwned');
+
+  const maliciousPath = '/tmp/$(touch ' + marker + ')/node.sock';
+
+  try {
+    execFileSync(process.execPath, ['-e', bitcoinSocketExistsScript, maliciousPath], {
+      stdio: 'ignore',
+    });
+  } catch {
+    // A non-zero exit (socket absent) is expected and irrelevant here.
+  }
+
+  const injected = existsSync(marker);
+  rmSync(tmp, { recursive: true, force: true });
+
+  assert.equal(
+    injected,
+    false,
+    'socket path was interpreted as a shell command (command injection via execSync)',
+  );
+});
+
+test('bitcoinSocketExistsScript exits 0 when the socket exists and non-zero otherwise', () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'sock-exists-'));
+  try {
+    const socketPath = path.join(tmp, 'node.sock');
+    assert.throws(
+      () =>
+        execFileSync(process.execPath, ['-e', bitcoinSocketExistsScript, socketPath], {
+          stdio: 'ignore',
+        }),
+      /Command failed/,
+      'missing socket path should exit non-zero',
+    );
+    writeFileSync(socketPath, '');
+    execFileSync(process.execPath, ['-e', bitcoinSocketExistsScript, socketPath], {
+      stdio: 'ignore',
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/server/src/bitcoin-socket-exists.ts
+++ b/server/src/bitcoin-socket-exists.ts
@@ -1,12 +1,15 @@
 export const bitcoinSocketExistsScript = `const fs = require('fs');
-const { execSync } = require('child_process');
 
 const socketPath = process.argv[1];
 const dir = require('path').dirname(socketPath);
 
 try {
   console.log('DEBUG: Checking path:', socketPath);
-  console.log('DEBUG: Directory contents:', execSync('ls -la ' + dir).toString());
+  // DO NOT REMOVE: sadly, on Docker Desktop for macOS, a host Unix socket is not
+  // visible to fs.existsSync until its parent directory has been read.
+  // This readdirSync populates the file-sharing cache that the existence
+  // check below relies on.
+  fs.readdirSync(dir);
   console.log('DEBUG: exists:', fs.existsSync(socketPath));
 } catch(e) {
   console.log('DEBUG ERROR:', e.message);


### PR DESCRIPTION
closes https://github.com/project-loupe/audit-sv2-ui/issues/6

needs testing on linux to see if the node.sock probe still working from docker and dev envs